### PR TITLE
Hotfix/node 695 move body tests

### DIFF
--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-multipart": "^1.0.5",

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-cookie": "^1.0.0",

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.0.0",
+    "version": "3.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/lerna.json
+++ b/lerna.json
@@ -9,5 +9,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.0.0"
+  "version": "3.1.0"
 }

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.0.0",
+    "@contrast/test-bench-utils": "^3.1.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/test-bench-utils/lib/routes.js
+++ b/test-bench-utils/lib/routes.js
@@ -38,7 +38,7 @@ module.exports = {
     name: 'Path Traversal',
     link: 'https://www.owasp.org/index.php/pathTraversal',
     products: ['Assess', 'Protect'],
-    inputs: ['headers', 'query'],
+    inputs: ['headers', 'query', 'body'],
     sinks: sinks.pathTraversal
   },
   sqlInjection: {

--- a/test-bench-utils/lib/sinks/pathTraversal.js
+++ b/test-bench-utils/lib/sinks/pathTraversal.js
@@ -48,6 +48,10 @@ module.exports['fs.readFileSync'] = async function readFileSync(
     const result = fs.readFileSync(path).toString();
     return pre(result);
   } catch (err) {
+    // properly throw error from protect
+    if (err.type === 'contrast') {
+      throw err;
+    }
     return pre(errMsg('readFileSync', err.message, safe));
   }
 };
@@ -95,6 +99,10 @@ module.exports['fs.writeFileSync'] = async function writeFileSync(
     fs.writeFileSync(path, 'stuff');
     return `Wrote to ${path}`;
   } catch (err) {
+    // properly throw error from protect
+    if (err.type === 'contrast') {
+      throw err;
+    }
     return pre(errMsg('writeFileSync', err.message, safe));
   }
 };

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/public/views/cmdInjection.ejs
+++ b/test-bench-utils/public/views/cmdInjection.ejs
@@ -13,6 +13,8 @@
         <button type="submit" class="btn btn-primary">Submit</button>
       </form>
     <% }); %>
+  </div>
+</div>
 <div class="row">
   <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
     <h4 class="sub-header">POST cookies</h4>
@@ -22,8 +24,6 @@
     <p><pre>curl http://localhost:3000<%= sink.url %>/<%= safety %> -X POST -b "input=test &whoami"</pre></p>
     <% }); %>
     <% }); %>
-  </div>
-</div>
   </div>
 </div>
 <% include ../partials/safeButtons %>

--- a/test-bench-utils/public/views/pathTraversal.ejs
+++ b/test-bench-utils/public/views/pathTraversal.ejs
@@ -1,9 +1,3 @@
-<style>
-  form {
-    padding-bottom: 10px;
-  }
-</style>
-
 <h1 class="page-header"><%= name %></h1>
 <% include ../partials/ruleInfo.ejs %>
 <% groupedSinkData.query.forEach(function(sink, i) { %>
@@ -26,9 +20,22 @@
     </form>
     <h4 class="sub-header">Headers</h4>
     <% headerSink = groupedSinkData.headers[i] %>
-    <% ['unsafe', 'safe', 'noop'].forEach(function(safety) { %>
-    <p><pre>curl http://localhost:3000<%= headerSink.url %>/<%= safety %> -H "input: ../../../../../../../../../../../../etc/passwd"</pre></p>
-    <% }); %>
+      <% ['unsafe', 'safe', 'noop'].forEach(function(safety) { %>
+      <p><pre>curl http://localhost:3000<%= headerSink.url %>/<%= safety %> -H "input: ../../../../../../../../../../../../etc/passwd"</pre></p>
+      <% }); %>
+    <% bodySink = groupedSinkData.body[i] %>
+    <h4 class="sub-header">Body</h4>
+    <form method="<%= bodySink.method %>" action="<%= bodySink.url %>/unsafe" target="_blank">
+      <div class="form-group">
+        <label for="exampleInputEmail1">Path</label>
+        <input
+          name="input"
+          class="form-control"
+          value="../../../../../../../../../../../../etc/passwd"
+        />
+      </div>
+      <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
   </div>
 </div>
 <% }); %>


### PR DESCRIPTION
- Added body as a valid input type for path traversal
- Fixed the path traversal sync sinks to properly throw 403s in protect
- fixed some html in cmdInjection