### PR TITLE
added check to not fail when injecting a function into ssjs sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default, when running `npm install` in the root of this repo,
 each of the specified package directories, as well as `npm link` shared
 dependencies.
 
-When bumping a package version, we will use `lerna version` instead of
+When bumping a package version, we will use `lerna publish <patch | minor | major>` instead of
 `npm version` inside _test-bench-utils_. This will keep versions in sync between
 packages.
 

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package.json
+++ b/express/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast index.js",
     "dev": "nodemon index.js",
-    "start": "node index.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node index.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -24,7 +24,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -20,8 +20,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast server.js",
     "dev": "nodemon server.js | pino-pretty",
-    "start": "node server.js | pino-pretty",
-    "postversion": "npm install --package-lock-only"
+    "start": "node server.js | pino-pretty"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast server.js",
     "dev": "nodemon server.js",
-    "start": "node server.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node server.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast server.js",
     "dev": "nodemon server.js",
-    "start": "node server.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node server.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -46,9 +46,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast server.js",
     "dev": "nodemon server.js",
-    "start": "node server.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node server.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package.json
+++ b/koa/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast index.js",
     "dev": "nodemon index.js",
-    "start": "node index.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node index.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-cookie": "^1.0.0",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-cookie": "^1.0.0",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-cookie": "^1.0.0",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "koa": "^2.7.0",
     "koa-bodyparser": "^4.2.1",
     "koa-cookie": "^1.0.0",

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -40,9 +40,9 @@
             "dev": true
         },
         "@contrast/test-bench-utils": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-            "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+            "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
             "requires": {
                 "axios": "^0.19.0",
                 "bent": "^1.5.13",

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.3.0",
+    "version": "3.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.2.3",
+    "version": "3.3.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast server.js",
     "dev": "nodemon index.js",
-    "start": "node index.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node index.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.2.2"
+  "version": "3.2.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.2.1"
+  "version": "3.2.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.3.0"
+  "version": "3.3.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.2.3"
+  "version": "3.3.0"
 }

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -40,9 +40,9 @@
       "dev": true
     },
     "@contrast/test-bench-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.2.1.tgz",
-      "integrity": "sha512-PjQNy20MitvAuMcrVvhkzcX2RLPvFriEOjTKjGLZ9+ekBP0nCcWZuSrBBn7m1HknEJ/+GU2zAjDMpcaEr8duSQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@contrast/test-bench-utils/-/test-bench-utils-3.3.1.tgz",
+      "integrity": "sha512-ALpEFpZoFWL2xyXQkUM+YBycCr26SieMFiqW8lMGUWVIRH1KAqdKF6Soyup2p5aNLwBFOYYKQo2QkW2F8H8IOQ==",
       "requires": {
         "axios": "^0.19.0",
         "bent": "^1.5.13",

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.3.0",
+    "@contrast/test-bench-utils": "^3.3.1",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -17,8 +17,7 @@
   "scripts": {
     "contrast": "DEBUG=contrast:* node-contrast server/server.js",
     "dev": "nodemon server/server.js",
-    "start": "node server/server.js",
-    "postversion": "npm install --package-lock-only"
+    "start": "node server/server.js"
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.2.2",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -21,7 +21,7 @@
     "postversion": "npm install --package-lock-only"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.1",
+    "@contrast/test-bench-utils": "^3.2.2",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.2",
+    "@contrast/test-bench-utils": "^3.2.3",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.2.3",
+    "@contrast/test-bench-utils": "^3.3.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
     "node": ">=10.13.0"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap --ci --force-local",
-    "postversion": "npx lerna publish",
-    "postpublish": "npx lerna exec -- npm install --package-lock-only"
+    "postpublish": "npx lerna exec -- npm install --package-lock-only && git commit -a -m 'update versions' && git push"
   },
   "devDependencies": {
     "@contrast/eslint-config": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "node": ">=10.13.0"
   },
   "scripts": {
-    "postinstall": "lerna bootstrap --ci --force-local"
+    "postinstall": "lerna bootstrap --ci --force-local",
+    "postpublish": "npx lerna exec -- npm install --package-lock-only"
   },
   "devDependencies": {
     "@contrast/eslint-config": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "postinstall": "lerna bootstrap --ci --force-local",
+    "postversion": "npx lerna publish",
     "postpublish": "npx lerna exec -- npm install --package-lock-only"
   },
   "devDependencies": {

--- a/test-bench-utils/README.md
+++ b/test-bench-utils/README.md
@@ -70,6 +70,7 @@ to the _xxe_ endpoint as a potential attack value.
 ## Test Bench Applications
 Once you have configured the shared sink and view, consult the following
 instructions for including the shared functionality in each test bench app:
+
 - [express](https://github.com/Contrast-Security-OSS/NodeTestBenches/tree/master/express#adding-a-shared-vulnerability)
 - [fastify](https://github.com/Contrast-Security-OSS/NodeTestBenches/tree/master/fastify#adding-a-shared-vulnerability)
 - [hapi](https://github.com/Contrast-Security-OSS/NodeTestBenches/tree/master/hapi#adding-a-shared-vulnerability)

--- a/test-bench-utils/lib/sinks/ssjs.js
+++ b/test-bench-utils/lib/sinks/ssjs.js
@@ -15,7 +15,8 @@ module.exports.eval = async function _eval(
   if (safe) return 'SAFE';
   if (noop) return 'NOOP';
 
-  return eval(input);
+  const result = eval(input);
+  return typeof result === 'function' ? input : result;
 };
 
 /**
@@ -31,7 +32,8 @@ module.exports.Function = async function _Function(
   if (safe) return 'SAFE';
   if (noop) return 'NOOP';
 
-  return Function(`return ${input};`)();
+  const result = Function(`return ${input};`)();
+  return typeof result === 'function' ? input : result;
 };
 
 /**
@@ -50,5 +52,5 @@ module.exports['vm.runInNewContext'] = async function _runInNewContext(
 
   const sandbox = { value: '', process };
   vm.runInNewContext(`value = ${input}`, sandbox);
-  return sandbox.value;
+  return typeof sandbox.value === 'function' ? input : sandbox.value;
 };

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -63,5 +63,6 @@
   },
   "lint-staged": {
     "*.js": "eslint --fix"
-  }
+  },
+  "gitHead": "25b03943eabfd842661467319fea18cece7fd8de"
 }

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.2.3",
+  "version": "3.3.0",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -18,8 +18,7 @@
     "public/"
   ],
   "scripts": {
-    "lint": "eslint --fix lib/",
-    "postversion": "npm install --package-lock-only"
+    "lint": "eslint --fix lib/"
   },
   "engines": {
     "node": ">=10.13.0"

--- a/test-bench-utils/public/views/xss.ejs
+++ b/test-bench-utils/public/views/xss.ejs
@@ -34,29 +34,4 @@
     <% }); %>
   </div>
 </div>
-<div class="row">
-  <div class="col-xs-12 col-sm-6" style="padding-bottom: 30px;">
-    <h4 class="sub-header">POST Body</h4>
-    <% groupedSinkData.body.forEach(function(sink) { %>
-    <form
-      method="<%= sink.method %>"
-      action="<%= sink.url %>/unsafe"
-      target="_blank"
-    >
-      <div class="form-group">
-        <label><%= sink.key %>.input</label>
-        <input
-          name="input"
-          class="form-control"
-          value="<script>alert(1);</script>"
-        />
-      </div>
-      <% if (locals._csrf) { %>
-      <input name="_csrf" type="hidden" value="<%= _csrf %>" />
-      <% } %>
-      <button type="submit" class="btn btn-primary">Submit</button>
-    </form>
-    <% }); %>
-  </div>
-</div>
 <% include ../partials/safeButtons %>


### PR DESCRIPTION
SSJS sinks naively always returned result from the function.  This fails in most because in certain cases attacks return a function.  This just helps avoid noise when debugging screener failures