### PR TITLE
Node 873 stub dynamodb sinks

### DIFF
--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/express-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/express/package.json
+++ b/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/express-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Express application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "aws-sdk": "^2.397.0",
     "body-parser": "^1.14.2",
     "cookie-parser": "^1.4.3",

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package-lock.json
+++ b/fastify/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/fastify-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/fastify/package.json
+++ b/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/fastify-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Fastify application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -23,7 +23,7 @@
     "start": "node server.js | pino-pretty"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "ejs": "2.6.1",
     "fastify": "^2.12.0",
     "fastify-cookie": "^3.6.0",

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package-lock.json
+++ b/hapi17/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-17-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi17/package.json
+++ b/hapi17/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-17-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "@hapi/glue": "^5.0.0",
     "@hapi/hapi": "^17.8.5",
     "@hapi/hoek": "^6.1.3",

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-18-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@hapi/glue": "^6.2.0",
     "@hapi/hapi": "^18.4.0",
     "@hapi/hoek": "^9.0.3",

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-18-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/hapi-19-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/hapi-19-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Hapi application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "@hapi/glue": "^7.0.0",
     "@hapi/hapi": "^19.1.1",
     "@hapi/inert": "^6.0.1",

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/koa-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@koa/router": "^8.0.8",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.2.1",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@koa/router": "^8.0.8",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.2.1",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "@koa/router": "^8.0.8",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.2.1",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "@koa/router": "^8.0.8",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.2.1",

--- a/koa/package.json
+++ b/koa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/koa-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Koa application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "@koa/router": "^8.0.8",
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.2.1",

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.5.0",
+    "version": "3.6.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.5.0",
+    "version": "3.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.3.1",
+    "version": "3.4.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@contrast/kraken-test-bench",
-    "version": "3.4.0",
+    "version": "3.3.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/kraken-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Kraken application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "ejs": "^2.7.4",
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.5.0"
+  "version": "3.6.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.5.0"
+  "version": "3.4.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.4.0"
+  "version": "3.3.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.3.1"
+  "version": "3.4.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -10,5 +10,5 @@
     "loopback",
     "test-bench-utils"
   ],
-  "version": "3.4.0"
+  "version": "3.5.0"
 }

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package-lock.json
+++ b/loopback/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/loopback-test-bench",
-  "version": "3.4.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.4.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.5.0",
+    "@contrast/test-bench-utils": "^3.6.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/loopback/package.json
+++ b/loopback/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contrast/loopback-test-bench",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.3.1",
   "description": "Intentionally vulnerable Loopback application",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",
@@ -20,7 +20,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "@contrast/test-bench-utils": "^3.4.0",
+    "@contrast/test-bench-utils": "^3.5.0",
     "body-parser": "^1.19.0",
     "compression": "^1.0.3",
     "cookie-parser": "^1.4.4",

--- a/test-bench-utils/lib/sinks/nosqlInjection/dynamodb.js
+++ b/test-bench-utils/lib/sinks/nosqlInjection/dynamodb.js
@@ -1,3 +1,76 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const db = new AWS.DynamoDB();
+function getDocClientparams(arg) {
+  return {
+    FilterExpression: 'id = :id',
+    ExpressionAttributeValues: {
+      ':id': arg
+    }
+  };
+}
+
+// hooker.hook(
+//   require('aws-sdk/lib/dynamodb/document_client').prototype,
+//   'makeServiceRequest',
+//   {
+//     post() {}
+//   }
+// );
+
+// hooker.hook(require('aws-sdk/lib/dynamodb/').prototype, 'makeRequest', {
+//   post() {}
+// });
+
+/**
+ * @param {string} input user input string
+ * @param {Object} opts
+ * @param {boolean=} opts.safe are we calling the sink safely?
+ * @param {boolean=} opts.noop are we calling the sink as a noop?
+ */
+// const origDocClientScan = AWS.DynamoDB.DocumentClient.prototype.scan;
+const documentClient = new AWS.DynamoDB.DocumentClient();
+documentClient.scan = function overloadedDocClientScan(params, callback) {
+  // Stubs go here
+  debugger;
+  return params;
+  // origDocClientScan.call(this, params, callback);
+};
+
+module.exports[
+  'aws-sdk.DynamoDB.DocumentClient.prototype.scan'
+] = async function scan(input, { safe = false, noop = false } = {}) {
+  if (noop) return 'NOOP';
+
+  // const fn = safe ? 'function() {}' : input;
+  const result = documentClient.scan(getDocClientparams(input));
+
+  return `<pre>${escape(JSON.stringify(result, null, 2))}</pre>`;
+};
+
+const origDbScan = AWS.DynamoDB.prototype.scan;
+AWS.DynamoDB.prototype.scan = async function overloadedDbScan(
+  params,
+  callback
+) {
+  // Stubs go here
+  debugger;
+  origDbScan.call(this, params, callback);
+};
+
+module.exports['aws-sdk.DynamoDB.prototype.scan'] = async function scan(
+  input,
+  { safe = false, noop = false } = {}
+) {
+  if (noop) return 'NOOP';
+
+  // const fn = safe ? 'function() {}' : input;
+  const result = await db.scan(params);
+
+  return `<pre>${escape(JSON.stringify(result, null, 2))}</pre>`;
+};
+
 // /**
 //  * @param {string} input user input string
 //  * @param {Object} opts

--- a/test-bench-utils/lib/sinks/nosqlInjection/dynamodb.js
+++ b/test-bench-utils/lib/sinks/nosqlInjection/dynamodb.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+
 function getDocClientParams(arg) {
   return {
     FilterExpression: 'id = :id',

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -197,6 +197,53 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "aws-sdk": {
+      "version": "2.693.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.693.0.tgz",
+      "integrity": "sha512-/0zy5IlE8wHrTXCxPYMSJGaqTKN1ulBBOSuWYeGxHU8pnTT6ZHpDdHlS83DHrVbsXnO/zq9prEf1nXRWlwgARw==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
+    },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -1065,6 +1112,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "execa": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
@@ -1884,6 +1936,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2931,6 +2988,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "ramda": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
@@ -3644,6 +3706,22 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
       }
     },
     "util-deprecate": {

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package-lock.json
+++ b/test-bench-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -24,6 +24,7 @@
     "node": ">=10.13.0"
   },
   "dependencies": {
+    "aws-sdk": "^2.693.0",
     "axios": "^0.19.0",
     "bent": "^1.5.13",
     "escape-html": "^1.0.3",

--- a/test-bench-utils/package.json
+++ b/test-bench-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contrast/test-bench-utils",
-  "version": "3.5.0",
+  "version": "3.4.0",
   "description": "Shared code to use in Contrast's web framework test apps.",
   "author": "Contrast Security <nodejs@contrastsecurity.com>",
   "license": "UNLICENSED",


### PR DESCRIPTION
Steps to Verify:

0. `npm i && npm link` in `test-bench-utils/` and `npm link @contrast/test-bench-utils` in whatever test bench app you use.
1. Spin up any test bench app 
2. Hit the routes and confirm `nosql-injection` gets reported

![Screen Shot 2020-06-12 at 3 57 05 PM](https://user-images.githubusercontent.com/14120224/84541500-85b52f00-acc5-11ea-8cdf-3a1b081f3ee4.png)

Additional Notes: 
- Once you hit the route you might see the rule report twice. I spent some time trying to dig in to why this was happening but could not discover the root cause. It looks like the post-hook runs twice for some reason