### PR TITLE
Hotfix/node 831 ssrf updates

### DIFF
--- a/express/.eslintrc.json
+++ b/express/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@contrast"
+}

--- a/express/utils/controllerFactory.js
+++ b/express/utils/controllerFactory.js
@@ -39,7 +39,6 @@ module.exports = function controllerFactory(
   const sinkData = utils.getSinkData(vulnerability, 'express');
   const groupedSinkData = utils.groupSinkData(sinkData);
   const routeMeta = utils.getRouteMeta(vulnerability);
-  const { mode } = routeMeta;
 
   router.get('/', function(req, res, next) {
     res.render(

--- a/express/utils/controllerFactory.js
+++ b/express/utils/controllerFactory.js
@@ -39,6 +39,7 @@ module.exports = function controllerFactory(
   const sinkData = utils.getSinkData(vulnerability, 'express');
   const groupedSinkData = utils.groupSinkData(sinkData);
   const routeMeta = utils.getRouteMeta(vulnerability);
+  const { mode } = routeMeta;
 
   router.get('/', function(req, res, next) {
     res.render(
@@ -62,13 +63,15 @@ module.exports = function controllerFactory(
   sinkData.forEach(({ method, uri, sink, key }) => {
     router[method](`${uri}/safe`, async (req, res, next) => {
       const input = utils.getInput({ locals, req, key });
-      const result = await sink(input, { safe: true });
+      const part = utils.getPart({ req, key });
+      const result = await sink(input, { safe: true, part  });
       respond(result, req, res, next);
     });
 
     router[method](`${uri}/unsafe`, async (req, res, next) => {
       const input = utils.getInput({ locals, req, key });
-      const result = await sink(input);
+      const part = utils.getPart({ req, key });
+      const result = await sink(input, { part });
       respond(result, req, res, next);
     });
 

--- a/express/vulnerabilities/ssrf/index.js
+++ b/express/vulnerabilities/ssrf/index.js
@@ -1,48 +1,10 @@
 'use strict';
+const { content } = require('@contrast/test-bench-utils');
+const controllerFactory = require('../../utils/controllerFactory');
 
-const { get } = require('lodash');
-const express = require('express');
-const path = require('path');
-
-const { utils } = require('@contrast/test-bench-utils');
-
-const EXAMPLE_URL = 'http://www.example.com';
-const router = express.Router();
-const sinkData = utils.getSinkData('ssrf', 'express');
-const routeMeta = utils.getRouteMeta('ssrf');
-
-/**
- * SSRF has different behavior, so we don't reuse the controllerFactory here.
- */
-router.get('/', function(req, res) {
-  res.render(path.resolve(__dirname, 'views', 'index'), {
-    ...routeMeta,
-    requestUrl: 'http://www.example.com',
-    sinkData
-  });
+module.exports = controllerFactory('ssrf', {
+  locals: {
+    requestUrl: content.ssrf.url
+  }
 });
 
-sinkData.forEach(({ method, sink, name, key }) => {
-  router[method](`/${name}/query`, async (req, res) => {
-    const { input } = get(req, key);
-    const url = `${EXAMPLE_URL}?q=${input}`;
-    const result = await sink(url);
-    res.send(result);
-  });
-
-  router[method](`/${name}/host`, async (req, res) => {
-    const { input } = get(req, key);
-    const url = `http://${input}`;
-    const result = await sink(url);
-    res.send(result);
-  });
-
-  router[method](`/${name}/path`, async (req, res) => {
-    const { input } = get(req, key);
-    const url = `${EXAMPLE_URL}/${input}`;
-    const result = await sink(url);
-    res.send(result);
-  });
-});
-
-module.exports = router;

--- a/express/vulnerabilities/ssrf/index.js
+++ b/express/vulnerabilities/ssrf/index.js
@@ -1,8 +1,13 @@
 'use strict';
 const { content } = require('@contrast/test-bench-utils');
+const { get } = require('lodash');
 const controllerFactory = require('../../utils/controllerFactory');
 
 module.exports = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url
   }

--- a/express/vulnerabilities/ssrf/index.js
+++ b/express/vulnerabilities/ssrf/index.js
@@ -30,9 +30,16 @@ sinkData.forEach(({ method, sink, name, key }) => {
     res.send(result);
   });
 
-  router[method](`/${name}/path`, async (req, res) => {
+  router[method](`/${name}/host`, async (req, res) => {
     const { input } = get(req, key);
     const url = `http://${input}`;
+    const result = await sink(url);
+    res.send(result);
+  });
+
+  router[method](`/${name}/path`, async (req, res) => {
+    const { input } = get(req, key);
+    const url = `${EXAMPLE_URL}/${input}`;
     const result = await sink(url);
     res.send(result);
   });

--- a/fastify/routes/ssrf.js
+++ b/fastify/routes/ssrf.js
@@ -1,48 +1,13 @@
 'use strict';
 
-const { get } = require('lodash');
-
-const { routes, utils } = require('@contrast/test-bench-utils');
-
-const EXAMPLE_URL = 'http://www.example.com';
-const { base } = routes.ssrf;
-const sinkData = utils.getSinkData('ssrf', 'express');
-const routeMeta = utils.getRouteMeta('ssrf');
+const { content } = require('@contrast/test-bench-utils');
+const controllerFactory = require('../utils/controllerFactory');
 
 /**
  * @vulnerability: ssrf
  */
-module.exports = async function routes(fastify, options) {
-  fastify.get(`${base}`, async (request, reply) => {
-    reply.view('ssrf', {
-      ...options,
-      ...routeMeta,
-      requestUrl: EXAMPLE_URL,
-      sinkData
-    });
-    return reply;
-  });
-
-  sinkData.forEach(({ method, name, sink, key }) => {
-    fastify[method](`${base}/${name}/query`, async function(request, reply) {
-      const { input } = get(request, key);
-      const url = `${EXAMPLE_URL}?q=${input}`;
-      const data = await sink(url);
-      return data;
-    });
-
-    fastify[method](`${base}/${name}/host`, async function(request, reply) {
-      const { input } = get(request, key);
-      const url = `http://${input}`;
-      const data = await sink(url);
-      return data;
-    });
-
-    fastify[method](`${base}/${name}/path`, async function(request, reply) {
-      const { input } = get(request, key);
-      const url = `${EXAMPLE_URL}/${input}`;
-      const data = await sink(url);
-      return data;
-    });
-  });
-};
+module.exports = controllerFactory('ssrf', {
+  locals: {
+    requestUrl: content.ssrf.url
+  }
+});

--- a/fastify/routes/ssrf.js
+++ b/fastify/routes/ssrf.js
@@ -31,9 +31,16 @@ module.exports = async function routes(fastify, options) {
       return data;
     });
 
-    fastify[method](`${base}/${name}/path`, async function(request, reply) {
+    fastify[method](`${base}/${name}/host`, async function(request, reply) {
       const { input } = get(request, key);
       const url = `http://${input}`;
+      const data = await sink(url);
+      return data;
+    });
+
+    fastify[method](`${base}/${name}/path`, async function(request, reply) {
+      const { input } = get(request, key);
+      const url = `${EXAMPLE_URL}/${input}`;
       const data = await sink(url);
       return data;
     });

--- a/fastify/routes/ssrf.js
+++ b/fastify/routes/ssrf.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { get } = require('lodash');
 const { content } = require('@contrast/test-bench-utils');
 const controllerFactory = require('../utils/controllerFactory');
 
@@ -7,6 +8,10 @@ const controllerFactory = require('../utils/controllerFactory');
  * @vulnerability: ssrf
  */
 module.exports = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url
   }

--- a/fastify/utils/controllerFactory.js
+++ b/fastify/utils/controllerFactory.js
@@ -50,13 +50,15 @@ module.exports = function controllerFactory(
     sinkData.forEach(({ method, url, sink, key }) => {
       fastify[method](`${url}/safe`, async (request, reply) => {
         const input = utils.getInput({ locals, req: request, key });
-        const result = await sink(input, { safe: true });
+        const part = utils.getPart({ req: request, key });
+        const result = await sink(input, { safe: true, part });
         respond(result, request, reply);
       });
 
       fastify[method](`${url}/unsafe`, async (request, reply) => {
         const input = utils.getInput({ locals, req: request, key });
-        const result = await sink(input);
+        const part = utils.getPart({ req: request, key });
+        const result = await sink(input, { part });
         // adding this in cases where the sink returns undefined
         // fastify shits the bed in this case with a FST_ERR_PROMISE_NOT_FULLFILLED
         // i have only really seen this in ssjs where we eval('console.log("1");');

--- a/fastify/utils/controllerFactory.js
+++ b/fastify/utils/controllerFactory.js
@@ -29,7 +29,7 @@ const defaultRespond = (result, request, reply) => {
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { locals = {}, respond = defaultRespond } = {}
+  { locals = {}, respond = defaultRespond, getInput = utils.getInput } = {}
 ) {
   const sinkData = utils.getSinkData(vulnerability, 'express');
   const groupedSinkData = utils.groupSinkData(sinkData);
@@ -49,16 +49,14 @@ module.exports = function controllerFactory(
 
     sinkData.forEach(({ method, url, sink, key }) => {
       fastify[method](`${url}/safe`, async (request, reply) => {
-        const input = utils.getInput({ locals, req: request, key });
-        const part = utils.getPart({ req: request, key });
-        const result = await sink(input, { safe: true, part });
+        const input = getInput({ locals, req: request, key });
+        const result = await sink(input, { safe: true });
         respond(result, request, reply);
       });
 
       fastify[method](`${url}/unsafe`, async (request, reply) => {
-        const input = utils.getInput({ locals, req: request, key });
-        const part = utils.getPart({ req: request, key });
-        const result = await sink(input, { part });
+        const input = getInput({ locals, req: request, key });
+        const result = await sink(input);
         // adding this in cases where the sink returns undefined
         // fastify shits the bed in this case with a FST_ERR_PROMISE_NOT_FULLFILLED
         // i have only really seen this in ssjs where we eval('console.log("1");');

--- a/hapi18/routes/ssrf/index.js
+++ b/hapi18/routes/ssrf/index.js
@@ -1,63 +1,10 @@
 'use strict';
-
-const Hoek = require('@hapi/hoek');
-
-const { utils } = require('@contrast/test-bench-utils');
-
-const EXAMPLE_URL = 'http://www.example.com';
+const { content } = require('@contrast/test-bench-utils');
+const controllerFactory = require('../../utils/controllerFactory');
 
 exports.name = 'hapitestbench.ssrf';
-exports.register = function(server, options) {
-  const sinkData = utils.getSinkData('ssrf', 'hapi');
-  const routeMeta = utils.getRouteMeta('ssrf');
-
-  server.route({
-    method: 'GET',
-    path: '/',
-    handler: {
-      view: {
-        template: 'ssrf',
-        context: {
-          ...routeMeta,
-          requestUrl: EXAMPLE_URL,
-          sinkData
-        }
-      }
-    }
-  });
-
-  sinkData.forEach(({ name, method, sink, key }) => {
-    server.route([
-      {
-        path: `/${name}/query`,
-        method,
-        handler: async (request, h) => {
-          const { input } = Hoek.reach(request, key);
-          const url = `${EXAMPLE_URL}?q=${input}`;
-          const data = await sink(url);
-          return data;
-        }
-      },
-      {
-        path: `/${name}/path`,
-        method,
-        handler: async (request, h) => {
-          const { input } = Hoek.reach(request, key);
-          const url = `${EXAMPLE_URL}/${input}`;
-          const data = await sink(url);
-          return data;
-        }
-      },
-      {
-        path: `/${name}/host`,
-        method,
-        handler: async (request, h) => {
-          const { input } = Hoek.reach(request, key);
-          const url = `https://${input}`;
-          const data = await sink(url);
-          return data;
-        }
-      }
-    ]);
-  });
-};
+exports.register = controllerFactory('ssrf', {
+  locals: {
+    requestUrl: content.ssrf.url
+  }
+});

--- a/hapi18/routes/ssrf/index.js
+++ b/hapi18/routes/ssrf/index.js
@@ -1,9 +1,14 @@
 'use strict';
 const { content } = require('@contrast/test-bench-utils');
 const controllerFactory = require('../../utils/controllerFactory');
+const { get } = require('lodash');
 
 exports.name = 'hapitestbench.ssrf';
 exports.register = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url
   }

--- a/hapi18/routes/ssrf/index.js
+++ b/hapi18/routes/ssrf/index.js
@@ -43,6 +43,16 @@ exports.register = function(server, options) {
         method,
         handler: async (request, h) => {
           const { input } = Hoek.reach(request, key);
+          const url = `${EXAMPLE_URL}/${input}`;
+          const data = await sink(url);
+          return data;
+        }
+      },
+      {
+        path: `/${name}/host`,
+        method,
+        handler: async (request, h) => {
+          const { input } = Hoek.reach(request, key);
           const url = `https://${input}`;
           const data = await sink(url);
           return data;

--- a/hapi18/utils/controllerFactory.js
+++ b/hapi18/utils/controllerFactory.js
@@ -27,7 +27,7 @@ const defaultRespond = (result, request, h) => result;
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { locals = {}, respond = defaultRespond } = {}
+  { locals = {}, respond = defaultRespond, getInput = utils.getInput } = {}
 ) {
   return (server, options) => {
     const sinkData = utils.getSinkData(vulnerability, 'hapi');
@@ -52,9 +52,8 @@ module.exports = function controllerFactory(
           path: `${uri}/safe`,
           method: [method],
           handler: async (request, h) => {
-            const input = utils.getInput({ locals, req: request, key });
-            const part = utils.getPart({ req: request, key });
-            const result = await sink(input, { safe: true, part });
+            const input = getInput({ locals, req: request, key });
+            const result = await sink(input, { safe: true });
             return respond(result, request, h);
           }
         },
@@ -62,9 +61,8 @@ module.exports = function controllerFactory(
           path: `${uri}/unsafe`,
           method: [method],
           handler: async (request, h) => {
-            const input = utils.getInput({ locals, req: request, key });
-            const part = utils.getPart({ req: request, key });
-            const result = await sink(input, { part });
+            const input = getInput({ locals, req: request, key });
+            const result = await sink(input);
             return respond(result, request, h);
           }
         },

--- a/hapi18/utils/controllerFactory.js
+++ b/hapi18/utils/controllerFactory.js
@@ -53,7 +53,8 @@ module.exports = function controllerFactory(
           method: [method],
           handler: async (request, h) => {
             const input = utils.getInput({ locals, req: request, key });
-            const result = await sink(input, { safe: true });
+            const part = utils.getPart({ req: request, key });
+            const result = await sink(input, { safe: true, part });
             return respond(result, request, h);
           }
         },
@@ -62,7 +63,8 @@ module.exports = function controllerFactory(
           method: [method],
           handler: async (request, h) => {
             const input = utils.getInput({ locals, req: request, key });
-            const result = await sink(input);
+            const part = utils.getPart({ req: request, key });
+            const result = await sink(input, { part });
             return respond(result, request, h);
           }
         },

--- a/hapi19/routes/ssrf/index.js
+++ b/hapi19/routes/ssrf/index.js
@@ -1,63 +1,10 @@
 'use strict';
-
-const Hoek = require('@hapi/hoek');
-
-const { utils } = require('@contrast/test-bench-utils');
-
-const EXAMPLE_URL = 'http://www.example.com';
+const { content } = require('@contrast/test-bench-utils');
+const controllerFactory = require('../../utils/controllerFactory');
 
 exports.name = 'hapitestbench.ssrf';
-exports.register = function(server, options) {
-  const sinkData = utils.getSinkData('ssrf', 'hapi');
-  const routeMeta = utils.getRouteMeta('ssrf');
-
-  server.route({
-    method: 'GET',
-    path: '/',
-    handler: {
-      view: {
-        template: 'ssrf',
-        context: {
-          ...routeMeta,
-          requestUrl: EXAMPLE_URL,
-          sinkData
-        }
-      }
-    }
-  });
-
-  sinkData.forEach(({ name, method, sink, key }) => {
-    server.route([
-      {
-        path: `/${name}/query`,
-        method,
-        handler: async (request, h) => {
-          const { input } = Hoek.reach(request, key);
-          const url = `${EXAMPLE_URL}?q=${input}`;
-          const data = await sink(url);
-          return data;
-        }
-      },
-      {
-        path: `/${name}/path`,
-        method,
-        handler: async (request, h) => {
-          const { input } = Hoek.reach(request, key);
-          const url = `${EXAMPLE_URL}/${input}`;
-          const data = await sink(url);
-          return data;
-        }
-      },
-      {
-        path: `/${name}/host`,
-        method,
-        handler: async (request, h) => {
-          const { input } = Hoek.reach(request, key);
-          const url = `https://${input}`;
-          const data = await sink(url);
-          return data;
-        }
-      }
-    ]);
-  });
-};
+exports.register = controllerFactory('ssrf', {
+  locals: {
+    requestUrl: content.ssrf.url
+  }
+});

--- a/hapi19/routes/ssrf/index.js
+++ b/hapi19/routes/ssrf/index.js
@@ -1,9 +1,14 @@
 'use strict';
 const { content } = require('@contrast/test-bench-utils');
 const controllerFactory = require('../../utils/controllerFactory');
+const { get } = require('lodash');
 
 exports.name = 'hapitestbench.ssrf';
 exports.register = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url
   }

--- a/hapi19/routes/ssrf/index.js
+++ b/hapi19/routes/ssrf/index.js
@@ -43,6 +43,16 @@ exports.register = function(server, options) {
         method,
         handler: async (request, h) => {
           const { input } = Hoek.reach(request, key);
+          const url = `${EXAMPLE_URL}/${input}`;
+          const data = await sink(url);
+          return data;
+        }
+      },
+      {
+        path: `/${name}/host`,
+        method,
+        handler: async (request, h) => {
+          const { input } = Hoek.reach(request, key);
           const url = `https://${input}`;
           const data = await sink(url);
           return data;

--- a/hapi19/utils/controllerFactory.js
+++ b/hapi19/utils/controllerFactory.js
@@ -27,7 +27,7 @@ const defaultRespond = (result, request, h) => result;
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { locals = {}, respond = defaultRespond } = {}
+  { locals = {}, respond = defaultRespond, getInput = utils.getInput } = {}
 ) {
   return (server, options) => {
     const sinkData = utils.getSinkData(vulnerability, 'hapi');
@@ -52,9 +52,8 @@ module.exports = function controllerFactory(
           path: `${uri}/safe`,
           method: [method],
           handler: async (request, h) => {
-            const input = utils.getInput({ locals, req: request, key });
-            const part = utils.getPart({ req: request, key });
-            const result = await sink(input, { safe: true, part });
+            const input = getInput({ locals, req: request, key });
+            const result = await sink(input, { safe: true });
             return respond(result, request, h);
           }
         },
@@ -62,9 +61,8 @@ module.exports = function controllerFactory(
           path: `${uri}/unsafe`,
           method: [method],
           handler: async (request, h) => {
-            const input = utils.getInput({ locals, req: request, key });
-            const part = utils.getPart({ req: request, key });
-            const result = await sink(input, { part });
+            const input = getInput({ locals, req: request, key });
+            const result = await sink(input);
             return respond(result, request, h);
           }
         },

--- a/hapi19/utils/controllerFactory.js
+++ b/hapi19/utils/controllerFactory.js
@@ -53,7 +53,8 @@ module.exports = function controllerFactory(
           method: [method],
           handler: async (request, h) => {
             const input = utils.getInput({ locals, req: request, key });
-            const result = await sink(input, { safe: true });
+            const part = utils.getPart({ req: request, key });
+            const result = await sink(input, { safe: true, part });
             return respond(result, request, h);
           }
         },
@@ -62,7 +63,8 @@ module.exports = function controllerFactory(
           method: [method],
           handler: async (request, h) => {
             const input = utils.getInput({ locals, req: request, key });
-            const result = await sink(input);
+            const part = utils.getPart({ req: request, key });
+            const result = await sink(input, { part });
             return respond(result, request, h);
           }
         },

--- a/koa/routes/ssrf.js
+++ b/koa/routes/ssrf.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { get } = require('lodash');
 const { content } = require('@contrast/test-bench-utils');
 const controllerFactory = require('../utils/controllerFactory');
 
@@ -7,6 +8,10 @@ const controllerFactory = require('../utils/controllerFactory');
  * @vulnerability: ssrf
  */
 module.exports = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url
   }

--- a/koa/routes/ssrf.js
+++ b/koa/routes/ssrf.js
@@ -1,46 +1,13 @@
 'use strict';
 
-const { get } = require('lodash');
-
-const { routes, utils } = require('@contrast/test-bench-utils');
-
-const EXAMPLE_URL = 'http://www.example.com';
-const { base } = routes.ssrf;
-const sinkData = utils.getSinkData('ssrf', 'koa');
-const routeMeta = utils.getRouteMeta('ssrf');
+const { content } = require('@contrast/test-bench-utils');
+const controllerFactory = require('../utils/controllerFactory');
 
 /**
  * @vulnerability: ssrf
  */
-module.exports = ({ router }) => {
-  router.get(base, (ctx) =>
-    ctx.render('ssrf', {
-      ...routeMeta,
-      requestUrl: EXAMPLE_URL,
-      sinkData
-    })
-  );
-
-  sinkData.forEach(({ method, name, sink, key }) => {
-    router[method](`${base}/${name}/query`, async function(ctx, next) {
-      const { input } = get(ctx, key);
-      const url = `${EXAMPLE_URL}?q=${input}`;
-      const data = await sink(url);
-      ctx.body = data;
-    });
-
-    router[method](`${base}/${name}/host`, async function(ctx, next) {
-      const { input } = get(ctx, key);
-      const url = `http://${input}`;
-      const data = await sink(url);
-      ctx.body = data;
-    });
-
-    router[method](`${base}/${name}/path`, async function(ctx, next) {
-      const { input } = get(ctx, key);
-      const url = `${EXAMPLE_URL}/${input}`;
-      const data = await sink(url);
-      ctx.body = data;
-    });
-  });
-};
+module.exports = controllerFactory('ssrf', {
+  locals: {
+    requestUrl: content.ssrf.url
+  }
+});

--- a/koa/routes/ssrf.js
+++ b/koa/routes/ssrf.js
@@ -29,9 +29,16 @@ module.exports = ({ router }) => {
       ctx.body = data;
     });
 
-    router[method](`${base}/${name}/path`, async function(ctx, next) {
+    router[method](`${base}/${name}/host`, async function(ctx, next) {
       const { input } = get(ctx, key);
       const url = `http://${input}`;
+      const data = await sink(url);
+      ctx.body = data;
+    });
+
+    router[method](`${base}/${name}/path`, async function(ctx, next) {
+      const { input } = get(ctx, key);
+      const url = `${EXAMPLE_URL}/${input}`;
       const data = await sink(url);
       ctx.body = data;
     });

--- a/koa/utils/controllerFactory.js
+++ b/koa/utils/controllerFactory.js
@@ -48,13 +48,15 @@ module.exports = function controllerFactory(
     sinkData.forEach(({ method, url, sink, key }) => {
       router[method](`${url}/safe`, async (ctx, next) => {
         const input = utils.getInput({ locals, req: ctx, key });
-        const result = await sink(input, { safe: true });
+        const part = utils.getPart({ req: ctx, key });
+        const result = await sink(input, { safe: true, part });
         respond(result, ctx, next);
       });
 
       router[method](`${url}/unsafe`, async (ctx, next) => {
         const input = utils.getInput({ locals, req: ctx, key });
-        const result = await sink(input);
+        const part = utils.getPart({ req: ctx, key });
+        const result = await sink(input, { part });
         respond(result, ctx, next);
       });
 

--- a/koa/utils/controllerFactory.js
+++ b/koa/utils/controllerFactory.js
@@ -29,7 +29,7 @@ const defaultRespond = (result, ctx, next) => {
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { locals = {}, respond = defaultRespond } = {}
+  { locals = {}, respond = defaultRespond, getInput = utils.getInput } = {}
 ) {
   const sinkData = utils.getSinkData(vulnerability, 'koa');
   const groupedSinkData = utils.groupSinkData(sinkData);
@@ -47,16 +47,14 @@ module.exports = function controllerFactory(
 
     sinkData.forEach(({ method, url, sink, key }) => {
       router[method](`${url}/safe`, async (ctx, next) => {
-        const input = utils.getInput({ locals, req: ctx, key });
-        const part = utils.getPart({ req: ctx, key });
-        const result = await sink(input, { safe: true, part });
+        const input = getInput({ locals, req: ctx, key });
+        const result = await sink(input, { safe: true });
         respond(result, ctx, next);
       });
 
       router[method](`${url}/unsafe`, async (ctx, next) => {
-        const input = utils.getInput({ locals, req: ctx, key });
-        const part = utils.getPart({ req: ctx, key });
-        const result = await sink(input, { part });
+        const input = getInput({ locals, req: ctx, key });
+        const result = await sink(input);
         respond(result, ctx, next);
       });
 

--- a/kraken/controllers/ssrf/index.js
+++ b/kraken/controllers/ssrf/index.js
@@ -1,35 +1,5 @@
 'use strict';
-const { get } = require('lodash');
 
-const SSRFModel = require('../../models/ssrf');
+const controllerFactory = require('../../utils/controllerFactory');
 
-module.exports = (router) => {
-  const model = new SSRFModel();
-
-  router.get('/', (req, res) => {
-    res.render('ssrf', model);
-  });
-
-  model.sinkData.forEach(({ method, sink, name, key }) => {
-    router[method](`/${name}/query`, async (req, res) => {
-      const { input } = get(req, key);
-      const url = `${model.requestUrl}?q=${input}`;
-      const result = await sink(url);
-      res.send(result);
-    });
-
-    router[method](`/${name}/host`, async (req, res) => {
-      const { input } = get(req, key);
-      const url = `http://${input}`;
-      const result = await sink(url);
-      res.send(result);
-    });
-
-    router[method](`/${name}/path`, async (req, res) => {
-      const { input } = get(req, key);
-      const url = `${model.requestUrl}/${input}`;
-      const result = await sink(url);
-      res.send(result);
-    });
-  });
-};
+module.exports = controllerFactory('ssrf');

--- a/kraken/controllers/ssrf/index.js
+++ b/kraken/controllers/ssrf/index.js
@@ -1,5 +1,10 @@
 'use strict';
-
+const { get } = require('lodash');
 const controllerFactory = require('../../utils/controllerFactory');
 
-module.exports = controllerFactory('ssrf');
+module.exports = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  }
+});

--- a/kraken/controllers/ssrf/index.js
+++ b/kraken/controllers/ssrf/index.js
@@ -18,9 +18,16 @@ module.exports = (router) => {
       res.send(result);
     });
 
-    router[method](`/${name}/path`, async (req, res) => {
+    router[method](`/${name}/host`, async (req, res) => {
       const { input } = get(req, key);
       const url = `http://${input}`;
+      const result = await sink(url);
+      res.send(result);
+    });
+
+    router[method](`/${name}/path`, async (req, res) => {
+      const { input } = get(req, key);
+      const url = `${model.requestUrl}/${input}`;
       const result = await sink(url);
       res.send(result);
     });

--- a/kraken/models/ssrf.js
+++ b/kraken/models/ssrf.js
@@ -1,14 +1,14 @@
-const { utils } = require('@contrast/test-bench-utils');
-
-const EXAMPLE_URL = 'http://www.example.com';
+const { utils, content } = require('@contrast/test-bench-utils');
 
 module.exports = function ServerSideRequestForgeryModel() {
   const sinkData = utils.getSinkData('ssrf', 'kraken');
   const routeMeta = utils.getRouteMeta('ssrf');
+  const groupedSinkData = utils.groupSinkData(sinkData);
 
   return {
     ...routeMeta,
-    requestUrl: EXAMPLE_URL,
-    sinkData
+    requestUrl: content.ssrf.url,
+    sinkData,
+    groupedSinkData
   };
 };

--- a/kraken/models/untrustedDeserialization.js
+++ b/kraken/models/untrustedDeserialization.js
@@ -3,6 +3,7 @@ const { utils } = require('@contrast/test-bench-utils');
 module.exports = function CommandInjectionModel() {
   const sinkData = utils.getSinkData('untrustedDeserialization', 'kraken');
   const routeMeta = utils.getRouteMeta('untrustedDeserialization');
+  console.log('here', sinkData);
 
   return {
     ...routeMeta,

--- a/kraken/public/templates/untrustedDeserialization.ejs
+++ b/kraken/public/templates/untrustedDeserialization.ejs
@@ -1,1 +1,1 @@
-<% include ../../node_modules/@contrast/test-bench-utils/public/views/ruleName.ejs %>
+<% include ../../node_modules/@contrast/test-bench-utils/public/views/untrustedDeserialization.ejs %>

--- a/kraken/utils/controllerFactory.js
+++ b/kraken/utils/controllerFactory.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {
-  utils: { getInput }
+  utils: { getInput, getPart }
 } = require('@contrast/test-bench-utils');
 
 /**
@@ -46,13 +46,15 @@ module.exports = function controllerFactory(
     model.sinkData.forEach(({ method, uri, sink, key }) => {
       router[method](`${uri}/safe`, async (req, res, next) => {
         const input = getInput({ locals: model, req, key });
-        const result = await sink(input, { safe: true });
+        const part = getPart({ req, key });
+        const result = await sink(input, { safe: true, part });
         respond(result, req, res, next);
       });
 
       router[method](`${uri}/unsafe`, async (req, res, next) => {
         const input = getInput({ locals: model, req, key });
-        const result = await sink(input);
+        const part = getPart({ req, key });
+        const result = await sink(input, { part });
         respond(result, req, res, next);
       });
 

--- a/kraken/utils/controllerFactory.js
+++ b/kraken/utils/controllerFactory.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const {
-  utils: { getInput, getPart }
-} = require('@contrast/test-bench-utils');
+const { utils } = require('@contrast/test-bench-utils');
 
 /**
  * Custom response functions allow you to change the functionality or return
@@ -30,7 +28,7 @@ const defaultRespond = (result, req, res, next) => res.send(result);
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { respond = defaultRespond } = {}
+  { respond = defaultRespond, getInput = utils.getInput } = {}
 ) {
   const Model = require(`../models/${vulnerability}`);
 
@@ -46,15 +44,13 @@ module.exports = function controllerFactory(
     model.sinkData.forEach(({ method, uri, sink, key }) => {
       router[method](`${uri}/safe`, async (req, res, next) => {
         const input = getInput({ locals: model, req, key });
-        const part = getPart({ req, key });
-        const result = await sink(input, { safe: true, part });
+        const result = await sink(input, { safe: true });
         respond(result, req, res, next);
       });
 
       router[method](`${uri}/unsafe`, async (req, res, next) => {
         const input = getInput({ locals: model, req, key });
-        const part = getPart({ req, key });
-        const result = await sink(input, { part });
+        const result = await sink(input);
         respond(result, req, res, next);
       });
 

--- a/loopback/server/boot/ssrf.js
+++ b/loopback/server/boot/ssrf.js
@@ -32,10 +32,21 @@ module.exports = function(server) {
       }
     });
 
-    router[method](`/${name}/path`, async (req, res, next) => {
+    router[method](`/${name}/host`, async (req, res, next) => {
       try {
         const { input } = get(req, key);
         const url = `http://${input}`;
+        const result = await sink(url);
+        res.send(result);
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    router[method](`/${name}/path`, async (req, res, next) => {
+      try {
+        const { input } = get(req, key);
+        const url = `${EXAMPLE_URL}/${input}`;
         const result = await sink(url);
         res.send(result);
       } catch (err) {

--- a/loopback/server/boot/ssrf.js
+++ b/loopback/server/boot/ssrf.js
@@ -1,9 +1,13 @@
 'use strict';
-
+const { get } = require('lodash');
 const { content } = require('@contrast/test-bench-utils');
 const controllerFactory = require('../utils/controllerFactory');
 
 module.exports = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url
   }

--- a/loopback/server/boot/ssrf.js
+++ b/loopback/server/boot/ssrf.js
@@ -1,59 +1,10 @@
 'use strict';
 
-const { get } = require('lodash');
-const { utils } = require('@contrast/test-bench-utils');
+const { content } = require('@contrast/test-bench-utils');
+const controllerFactory = require('../utils/controllerFactory');
 
-const EXAMPLE_URL = 'http://www.example.com';
-
-const sinkData = utils.getSinkData('ssrf', 'loopback');
-const routeMeta = utils.getRouteMeta('ssrf');
-
-// TODO
-module.exports = function(server) {
-  const router = server.loopback.Router();
-
-  router.get('/', function(req, res, next) {
-    res.render('pages/ssrf', {
-      ...routeMeta,
-      sinkData,
-      requestUrl: EXAMPLE_URL
-    });
-  });
-
-  sinkData.forEach(({ method, sink, name, key }) => {
-    router[method](`/${name}/query`, async (req, res, next) => {
-      try {
-        const { input } = get(req, key);
-        const url = `${EXAMPLE_URL}?q=${input}`;
-        const result = await sink(url);
-        res.send(result);
-      } catch (err) {
-        next(err);
-      }
-    });
-
-    router[method](`/${name}/host`, async (req, res, next) => {
-      try {
-        const { input } = get(req, key);
-        const url = `http://${input}`;
-        const result = await sink(url);
-        res.send(result);
-      } catch (err) {
-        next(err);
-      }
-    });
-
-    router[method](`/${name}/path`, async (req, res, next) => {
-      try {
-        const { input } = get(req, key);
-        const url = `${EXAMPLE_URL}/${input}`;
-        const result = await sink(url);
-        res.send(result);
-      } catch (err) {
-        next(err);
-      }
-    });
-  });
-
-  server.use('/ssrf', router);
-};
+module.exports = controllerFactory('ssrf', {
+  locals: {
+    requestUrl: content.ssrf.url
+  }
+});

--- a/loopback/server/utils/controllerFactory.js
+++ b/loopback/server/utils/controllerFactory.js
@@ -51,7 +51,8 @@ module.exports = function controllerFactory(
       router[method](`${uri}/safe`, async (req, res, next) => {
         try {
           const input = utils.getInput({ locals, req, key });
-          const result = await sink(input, { safe: true });
+          const part = utils.getPart({ req, key });
+          const result = await sink(input, { safe: true, part });
           respond(result, req, res, next);
         } catch (err) {
           next(err);
@@ -61,7 +62,8 @@ module.exports = function controllerFactory(
       router[method](`${uri}/unsafe`, async (req, res, next) => {
         try {
           const input = utils.getInput({ locals, req, key });
-          const result = await sink(input);
+          const part = utils.getPart({ req, key });
+          const result = await sink(input, { part });
           respond(result, req, res, next);
         } catch (err) {
           next(err);

--- a/loopback/server/utils/controllerFactory.js
+++ b/loopback/server/utils/controllerFactory.js
@@ -29,7 +29,7 @@ const defaultRespond = (result, req, res, next) => res.send(result);
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { locals = {}, respond = defaultRespond } = {}
+  { locals = {}, respond = defaultRespond, getInput = utils.getInput } = {}
 ) {
   const sinkData = utils.getSinkData(vulnerability, 'loopback');
   const groupedSinkData = utils.groupSinkData(sinkData);
@@ -50,9 +50,8 @@ module.exports = function controllerFactory(
     sinkData.forEach(({ method, uri, sink, key }) => {
       router[method](`${uri}/safe`, async (req, res, next) => {
         try {
-          const input = utils.getInput({ locals, req, key });
-          const part = utils.getPart({ req, key });
-          const result = await sink(input, { safe: true, part });
+          const input = getInput({ locals, req, key });
+          const result = await sink(input, { safe: true });
           respond(result, req, res, next);
         } catch (err) {
           next(err);
@@ -61,9 +60,8 @@ module.exports = function controllerFactory(
 
       router[method](`${uri}/unsafe`, async (req, res, next) => {
         try {
-          const input = utils.getInput({ locals, req, key });
-          const part = utils.getPart({ req, key });
-          const result = await sink(input, { part });
+          const input = getInput({ locals, req, key });
+          const result = await sink(input);
           respond(result, req, res, next);
         } catch (err) {
           next(err);

--- a/restify/utils/controllerFactory.js
+++ b/restify/utils/controllerFactory.js
@@ -15,7 +15,7 @@ const defaultRespond = (result, req, res, next) => res.send(result);
  */
 module.exports = function controllerFactory(
   vulnerability,
-  { locals = {}, respond = defaultRespond, router = new Router() } = {}
+  { locals = {}, respond = defaultRespond, router = new Router(), getInput = utils.getInput } = {}
 ) {
   const sinkData = utils.getSinkData(vulnerability, 'restify');
   const groupedSinkData = utils.groupSinkData(sinkData);
@@ -42,16 +42,14 @@ module.exports = function controllerFactory(
 
   sinkData.forEach(({ method, uri, sink, key }) => {
     router[method](`${uri}/safe`, async (req, res, next) => {
-      const input = utils.getInput({ locals, req, key });
-      const part = utils.getPart({ req, key });
-      const result = await sink(input, { safe: true, part });
+      const input = getInput({ locals, req, key });
+      const result = await sink(input, { safe: true });
       respond(result, req, res, next);
     });
 
     router[method](`${uri}/unsafe`, async (req, res, next) => {
-      const input = utils.getInput({ locals, req, key });
-      const part = utils.getPart({ req, key });
-      const result = await sink(input, { part });
+      const input = getInput({ locals, req, key });
+      const result = await sink(input);
       respond(result, req, res, next);
     });
 

--- a/restify/utils/controllerFactory.js
+++ b/restify/utils/controllerFactory.js
@@ -43,13 +43,15 @@ module.exports = function controllerFactory(
   sinkData.forEach(({ method, uri, sink, key }) => {
     router[method](`${uri}/safe`, async (req, res, next) => {
       const input = utils.getInput({ locals, req, key });
-      const result = await sink(input, { safe: true });
+      const part = utils.getPart({ req, key });
+      const result = await sink(input, { safe: true, part });
       respond(result, req, res, next);
     });
 
     router[method](`${uri}/unsafe`, async (req, res, next) => {
       const input = utils.getInput({ locals, req, key });
-      const result = await sink(input);
+      const part = utils.getPart({ req, key });
+      const result = await sink(input, { part });
       respond(result, req, res, next);
     });
 

--- a/restify/vulnerabilities/ssrf/index.js
+++ b/restify/vulnerabilities/ssrf/index.js
@@ -30,6 +30,13 @@ sinkData.forEach(({ method, sink, name, key }) => {
     res.send(result);
   });
 
+  router[method](`/${name}/host`, async (req, res) => {
+    const { input } = get(req, key);
+    const url = `http://${input}`;
+    const result = await sink(url);
+    res.send(result);
+  });
+
   router[method](`/${name}/path`, async (req, res) => {
     const { input } = get(req, key);
     const url = `http://${input}`;

--- a/restify/vulnerabilities/ssrf/index.js
+++ b/restify/vulnerabilities/ssrf/index.js
@@ -1,9 +1,13 @@
 'use strict';
-
+const { get } = require('lodash');
 const { content } = require('@contrast/test-bench-utils');
 const controllerFactory = require('../../utils/controllerFactory');
 
 module.exports = controllerFactory('ssrf', {
+  getInput({ req, key }) {
+    const { input, part } = get(req, key);
+    return [input, part];
+  },
   locals: {
     requestUrl: content.ssrf.url,
   },

--- a/test-bench-utils/lib/content/index.js
+++ b/test-bench-utils/lib/content/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   nosqlInjection: require('./nosqlInjection'),
-  xpathInjection: require('./xpathInjection')
+  xpathInjection: require('./xpathInjection'),
+  ssrf: require('./ssrf')
 };

--- a/test-bench-utils/lib/content/ssrf.js
+++ b/test-bench-utils/lib/content/ssrf.js
@@ -1,0 +1,1 @@
+module.exports.url = 'http://www.example.com';

--- a/test-bench-utils/lib/routes.js
+++ b/test-bench-utils/lib/routes.js
@@ -64,6 +64,7 @@ module.exports = {
     link: 'https://www.owasp.org/index.php/Server_Side_Request_Forgery',
     products: ['Assess'],
     inputs: ['query'],
+    parts: ['host', 'path', 'query'],
     // these are not sinks but the ssrf sinks file has helpers to make a request for each
     sinks: sinks.ssrf
   },

--- a/test-bench-utils/lib/sinks/ssrf.js
+++ b/test-bench-utils/lib/sinks/ssrf.js
@@ -15,9 +15,9 @@ const { url: EXAMPLE_URL } = require('../content/ssrf');
  */
 function formatUrl(input, part) {
   let url;
-  switch(part) {
+  switch (part) {
     case 'query':
-      url =  `${EXAMPLE_URL}?q=${input}`;
+      url = `${EXAMPLE_URL}?q=${input}`;
       break;
     case 'path':
       url = `${EXAMPLE_URL}/${input}`;
@@ -35,22 +35,22 @@ function formatUrl(input, part) {
  * custom route handlers.
  */
 
-exports.axios = async function makeAxiosRequest(input, { part }) {
+exports.axios = async function makeAxiosRequest([input, part]) {
   const url = formatUrl(input, part);
   return axios.get(url).then((response) => response.data);
 };
 
-exports.bent = async function makeBentRequest(input, { part }) {
+exports.bent = async function makeBentRequest([input, part]) {
   const url = formatUrl(input, part);
   return bent(url, 'GET', 'string', 200)('/');
 };
 
-exports.fetch = async function makeFetchRequest(input, { part }) {
+exports.fetch = async function makeFetchRequest([input, part]) {
   const url = formatUrl(input, part);
   return fetch(url).then((res) => res.text());
 };
 
-exports.request = async function makeRequestRequest(input, { part }) {
+exports.request = async function makeRequestRequest([input, part]) {
   const url = formatUrl(input, part);
   return new Promise((resolve, reject) => {
     request(url, (err, response, body) => {
@@ -60,7 +60,7 @@ exports.request = async function makeRequestRequest(input, { part }) {
   });
 };
 
-exports.superagent = async function makeSuperagentRequest(input, { part }) {
+exports.superagent = async function makeSuperagentRequest([input, part]) {
   const url = formatUrl(input, part);
   return superagent.get(url).then((res) => res.text);
 };

--- a/test-bench-utils/lib/sinks/ssrf.js
+++ b/test-bench-utils/lib/sinks/ssrf.js
@@ -7,6 +7,12 @@ const request = require('request');
 const superagent = require('superagent');
 const { url: EXAMPLE_URL } = require('../content/ssrf');
 
+/**
+ * Constructs a url based on input and a part field
+ * @param {string} input
+ * @param {string} part which part to place input
+ * @return {string} fully constructed url
+ */
 function formatUrl(input, part) {
   let url;
   switch(part) {

--- a/test-bench-utils/lib/sinks/ssrf.js
+++ b/test-bench-utils/lib/sinks/ssrf.js
@@ -5,25 +5,47 @@ const bent = require('bent');
 const fetch = require('node-fetch');
 const request = require('request');
 const superagent = require('superagent');
+const { url: EXAMPLE_URL } = require('../content/ssrf');
+
+function formatUrl(input, part) {
+  let url;
+  switch(part) {
+    case 'query':
+      url =  `${EXAMPLE_URL}?q=${input}`;
+      break;
+    case 'path':
+      url = `${EXAMPLE_URL}/${input}`;
+      break;
+    default:
+      url = `http://${input}`;
+      break;
+  }
+
+  return url;
+}
 
 /**
  * SSRF sinks have a different signature from other sink methods since we have
  * custom route handlers.
  */
 
-exports.axios = async function makeAxiosRequest(url) {
+exports.axios = async function makeAxiosRequest(input, { part }) {
+  const url = formatUrl(input, part);
   return axios.get(url).then((response) => response.data);
 };
 
-exports.bent = async function makeBentRequest(url) {
+exports.bent = async function makeBentRequest(input, { part }) {
+  const url = formatUrl(input, part);
   return bent(url, 'GET', 'string', 200)('/');
 };
 
-exports.fetch = async function makeFetchRequest(url) {
+exports.fetch = async function makeFetchRequest(input, { part }) {
+  const url = formatUrl(input, part);
   return fetch(url).then((res) => res.text());
 };
 
-exports.request = async function makeRequestRequest(url) {
+exports.request = async function makeRequestRequest(input, { part }) {
+  const url = formatUrl(input, part);
   return new Promise((resolve, reject) => {
     request(url, (err, response, body) => {
       if (err) reject(err);
@@ -32,6 +54,7 @@ exports.request = async function makeRequestRequest(url) {
   });
 };
 
-exports.superagent = async function makeSuperagentRequest(url) {
+exports.superagent = async function makeSuperagentRequest(input, { part }) {
+  const url = formatUrl(input, part);
   return superagent.get(url).then((res) => res.text);
 };

--- a/test-bench-utils/lib/utils.js
+++ b/test-bench-utils/lib/utils.js
@@ -109,6 +109,16 @@ module.exports.getInput = function getInput({ locals, req, key }) {
   return locals.input || get(req, key).input;
 };
 
-module.exports.getPart = function({ req, key, part }) {
+/**
+ * Gets value of part from request.
+ * Note: This is currently only used in ssrf to indicate which part of a URL
+ * to affect
+ *
+ * @param {Object} params
+ * @param {Object} params.req IncomingMessage
+ * @param {string} params.key key on request to get input from
+ *
+ */
+module.exports.getPart = function({ req, key }) {
   return get(req, key).part;
 }

--- a/test-bench-utils/lib/utils.js
+++ b/test-bench-utils/lib/utils.js
@@ -108,3 +108,7 @@ module.exports.getRouteMeta = function getRouteMeta(rule) {
 module.exports.getInput = function getInput({ locals, req, key }) {
   return locals.input || get(req, key).input;
 };
+
+module.exports.getPart = function({ req, key, part }) {
+  return get(req, key).part;
+}

--- a/test-bench-utils/lib/utils.js
+++ b/test-bench-utils/lib/utils.js
@@ -121,4 +121,4 @@ module.exports.getInput = function getInput({ locals, req, key }) {
  */
 module.exports.getPart = function({ req, key }) {
   return get(req, key).part;
-}
+};

--- a/test-bench-utils/public/views/ssrf.ejs
+++ b/test-bench-utils/public/views/ssrf.ejs
@@ -43,7 +43,7 @@
     <div style="overflow:auto">
       <p>Select part of url to contain tracked data.</p>
       <ul id="url-list" class="selections">
-        <li id="path-selection">
+        <li id="host-selection">
           <button type="submit" class="btn btn-warning">host</button>
         </li>
         <li id="path-selection">
@@ -77,8 +77,9 @@
      action: '/ssrf/{lib}/{url}',
      requestUrl: '<%= requestUrl %>',
      selectedLib: 'axios',
-     selectedUrlPart: 'path'
+     selectedUrlPart: 'host'
    };
+   debugger;
 
    $('#constructed-url').text(state.requestUrl);
 

--- a/test-bench-utils/public/views/ssrf.ejs
+++ b/test-bench-utils/public/views/ssrf.ejs
@@ -44,14 +44,16 @@
 
     <div>
       <form action="/ssrf" method="GET" target="test-bench-ssrf">
-        <p>The server will make a request to the following URL using the selected Node.js package.</p>
-        <pre id="constructed-url"></pre>
-        <br>
-        <label>Input Value</label>
-        <br>
-        <input name="input" class="form-control">
-        <br>
-        <input name="part" type="hidden">
+        <div class="form-group">
+          <p>The server will make a request to the following URL using the selected Node.js package.</p>
+          <pre id="constructed-url"></pre>
+          <br>
+          <label>Input Value</label>
+          <br>
+          <input name="input" class="form-control">
+          <br>
+          <input name="part" type="hidden">
+        </div>
         <button type="submit" class="btn btn-primary">Submit</button>
       </form>
     </div>

--- a/test-bench-utils/public/views/ssrf.ejs
+++ b/test-bench-utils/public/views/ssrf.ejs
@@ -22,36 +22,22 @@
     <div style="overflow:auto">
       <p>Select library to use when performing the server-side request.</p>
       <ul id="libs-list" class="selections">
-        <li id="axios-selection">
-          <button type="submit" class="btn btn-warning">axios</button>
+      <% groupedSinkData.query.forEach(function(sink) { %>
+        <li id="<%= sink.name %>-selection">
+          <button type="submit" class="btn btn-warning"><%= sink.name %></button>
         </li>
-        <li id="bent-selection">
-          <button type="submit" class="btn btn-warning">bent</button>
-        </li>
-        <li id="fetch-selection">
-          <button type="submit" class="btn btn-warning">fetch</button>
-        </li>
-        <li id="request-selection">
-          <button type="submit" class="btn btn-warning">request</button>
-        </li>
-        <li id="superagent-selection">
-          <button type="submit" class="btn btn-warning">superagent</button>
-        </li>
+      <% }); %>
       </ul>
     </div>
 
     <div style="overflow:auto">
       <p>Select part of url to contain tracked data.</p>
       <ul id="url-list" class="selections">
-        <li id="host-selection">
-          <button type="submit" class="btn btn-warning">host</button>
+        <% parts.forEach(function(part) { %>
+        <li id="<%= part %>-selection">
+          <button type="submit" class="btn btn-warning"><%= part %></button>
         </li>
-        <li id="path-selection">
-          <button type="submit" class="btn btn-warning">path</button>
-        </li>
-        <li id="query-selection">
-          <button type="submit" class="btn btn-warning">query</button>
-        </li>
+        <% }); %>
       </ul>
     </div>
     <br>
@@ -65,6 +51,7 @@
         <br>
         <input name="input" class="form-control">
         <br>
+        <input name="part" type="hidden">
         <button type="submit" class="btn btn-primary">Submit</button>
       </form>
     </div>
@@ -74,12 +61,11 @@
 <script type="text/javascript">
  $(() => {
    const state = {
-     action: '/ssrf/{lib}/{url}',
+     action: '/ssrf/query/{lib}/unsafe',
      requestUrl: '<%= requestUrl %>',
      selectedLib: 'axios',
      selectedUrlPart: 'host'
    };
-   debugger;
 
    $('#constructed-url').text(state.requestUrl);
 
@@ -121,9 +107,9 @@
    function setAction() {
      const action = state
        .action
-       .replace('{lib}', state.selectedLib)
-       .replace('{url}', state.selectedUrlPart);
+       .replace('{lib}', state.selectedLib);
 
+     $('[name=part]').val(state.selectedUrlPart);
      $('form').attr('action', action);
    }
 

--- a/test-bench-utils/public/views/ssrf.ejs
+++ b/test-bench-utils/public/views/ssrf.ejs
@@ -44,6 +44,9 @@
       <p>Select part of url to contain tracked data.</p>
       <ul id="url-list" class="selections">
         <li id="path-selection">
+          <button type="submit" class="btn btn-warning">host</button>
+        </li>
+        <li id="path-selection">
           <button type="submit" class="btn btn-warning">path</button>
         </li>
         <li id="query-selection">
@@ -103,8 +106,10 @@
 
    $('[name=input]').on('keyup', (e) => {
      const url = e.currentTarget.value
-      ? state.selectedUrlPart === 'path'
+      ? state.selectedUrlPart === 'host'
       ? `http://${e.currentTarget.value}`
+      : state.selectedUrlPart === 'path'
+      ? `${state.requestUrl}/${e.currentTarget.value}`
       : `${state.requestUrl}?input=${e.currentTarget.value}`
       : `${state.requestUrl}`
      $('#constructed-url').text(url)


### PR DESCRIPTION
This updates the js in the ssrf shared view to add a new `host` mode of ssrf.  It also updates all the controllers in every framework to add a new `host` route that passing in a tracked host and updates `path` route to only pass in path segment(which should not report SSRF trace).  [Screener Config PR](https://bitbucket.org/contrastsecurity/darpa-testing-config/pull-requests/198/udpated-screener-configs-to-add-the-new)