### PR TITLE
fixed the unsafe file upload sink

### DIFF
--- a/test-bench-utils/lib/sinks/unsafeFileUpload.js
+++ b/test-bench-utils/lib/sinks/unsafeFileUpload.js
@@ -6,9 +6,8 @@
  */
 
 /**
- * @param {Object} params
- * @param {string} params.input user input string
+ * @param {string} input user input string
  */
-module.exports.upload = async function upload({ input }) {
+module.exports.upload = async function upload(input) {
   return input;
 };


### PR DESCRIPTION
We changed the signatures to sinks to be an object.  However unsafe file upload doesn't use the `utils.getInput`, so the sink was updated to pass in an object with a key of `input` when it didn't have to be