### PR TITLE
added logic to account for another redirect use case

### DIFF
--- a/restify/vulnerabilities/unvalidatedRedirect/index.js
+++ b/restify/vulnerabilities/unvalidatedRedirect/index.js
@@ -5,8 +5,12 @@ const controllerFactory = require('../../utils/controllerFactory');
 module.exports = controllerFactory('unvalidatedRedirect', {
   locals: { res: 'res' },
   respond(result, req, res, next) {
-    result.status
-      ? res.redirect(301, result.path, next)
-      : res.redirect(result.path, next);
+    if (result.status) {
+      res.redirect(301, result.path, next);
+    } else if (result.hostname) {
+      res.redirect({ hostname: result.path, pathname: '/' }, next);
+    } else {
+      res.redirect(result.path, next);
+    }
   },
 });

--- a/test-bench-utils/lib/sinks/unvalidatedRedirect.js
+++ b/test-bench-utils/lib/sinks/unvalidatedRedirect.js
@@ -25,6 +25,24 @@ module.exports['redirect(path)'] = async function redirect(
  * @param {boolean=} opts.safe are we calling the sink safely?
  * @param {boolean=} opts.noop are we calling the sink as a noop?
  */
+module.exports['redirect({ hostname })'] = async function redirect(
+  { input },
+  { safe = false, noop = false } = {}
+) {
+  if (noop) return { path: 'http://www.example.com' };
+
+  const path = safe ? encodeURIComponent(input) : input;
+
+  return { hostname: true, path };
+};
+
+/**
+ * @param {Object} params
+ * @param {string} params.input user input string
+ * @param {Object} opts
+ * @param {boolean=} opts.safe are we calling the sink safely?
+ * @param {boolean=} opts.noop are we calling the sink as a noop?
+ */
 module.exports['redirect(status, path)'] = async function redirect(
   { input },
   { safe = false, noop = false } = {}


### PR DESCRIPTION
Restify allows you to pass an object in as first arg to `res.redirect`. This adds that capability