### PR TITLE
fixed ufu handler now that it returns an object

### DIFF
--- a/fastify/routes/unsafeFileUpload.js
+++ b/fastify/routes/unsafeFileUpload.js
@@ -4,6 +4,7 @@ const { routes, utils } = require('@contrast/test-bench-utils');
 
 const sinkData = utils.getSinkData('unsafeFileUpload', 'express');
 const routeMeta = utils.getRouteMeta('unsafeFileUpload');
+const { isEmpty } = require('lodash');
 
 module.exports = async function route(fastify, options) {
   fastify.get(routes.unsafeFileUpload.base, async (request, reply) => {
@@ -20,10 +21,10 @@ module.exports = async function route(fastify, options) {
       const inputs = utils.getInput(req, key, params);
       // We sometimes use these routes just to test UFU and there is no input
       // Just return 'done' in that case
-      if (inputs) {
-        return await sink(inputs);
-      } else {
+      if (isEmpty(inputs)) {
         return 'done';
+      } else {
+        return await sink(inputs);
       }
     });
   });


### PR DESCRIPTION
This was a regression when we refactored the test-bench-utils a few weeks ago.

Steps to reproduce, use this harness to make a request
```
import requests
import os

session = requests.Session()

f = open(os.path.join('./bad-file.php'), mode='rb')
files = { 'file': ('bad-file.php', f.read().decode(errors='replace')) }

req = requests.Request('POST', 'http://localhost:3000/unsafeFileUpload/body/upload', files=files, headers={'Accept': 'text/html'}).prepare()

response = session.send(req, allow_redirects=False, verify=False)

print(response)
```

Expected result 200 with response of `done`.

**Note**: You don't need the agent to repro