### PR TITLE
wrap async restify handlers to ensure framework can properly handle errors

### DIFF
--- a/restify/utils/controllerFactory.js
+++ b/restify/utils/controllerFactory.js
@@ -3,18 +3,7 @@
 const { utils } = require('@contrast/test-bench-utils');
 const path = require('path');
 const { Router } = require('restify-router');
-
-/**
- * Wraps the async handlers in a promise chain to properly send errors
- * to next
- *
- * @param {Function} handler
- */
-function wrapHandler(handler) {
-  return (req, res, next) => {
-    Promise.resolve(handler(req, res, next)).catch(next);
-  };
-}
+const wrapHandler = require('./wrapHandler');
 
 const defaultRespond = (result, req, res, next) => res.send(result);
 /**

--- a/restify/utils/wrapHandler.js
+++ b/restify/utils/wrapHandler.js
@@ -1,0 +1,11 @@
+/**
+ * Wraps the async handlers in a promise chain to properly send errors
+ * to next
+ *
+ * @param {Function} handler
+ */
+module.exports = function wrapHandler(handler) {
+  return (req, res, next) => {
+    Promise.resolve(handler(req, res, next)).catch(next);
+  };
+};

--- a/restify/vulnerabilities/unsafeFileUpload/index.js
+++ b/restify/vulnerabilities/unsafeFileUpload/index.js
@@ -2,6 +2,7 @@
 
 const { Router } = require('restify-router');
 const path = require('path');
+const wrapHandler = require('../../utils/wrapHandler');
 
 const { utils } = require('@contrast/test-bench-utils');
 
@@ -17,11 +18,14 @@ router.get('/', function (req, res) {
 });
 
 sinkData.forEach(({ method, params, uri, sink, key }) => {
-  router[method](uri, async (req, res) => {
-    const inputs = utils.getInput(req, key, params);
-    const result = await sink(inputs); // doesn't really do anything
-    res.send(result);
-  });
+  router[method](
+    uri,
+    wrapHandler(async (req, res) => {
+      const inputs = utils.getInput(req, key, params);
+      const result = await sink(inputs); // doesn't really do anything
+      res.send(result);
+    })
+  );
 });
 
 module.exports = router;


### PR DESCRIPTION
It occurred to me while trying to support protect in restify that it doesn't natively support async handlers.  Similarly to express we need a shim in the handlers to properly wrap them in try/catch.  

