### PR TITLE
Hotfix/node 1130 mount volumes

### DIFF
--- a/express/entry.sh
+++ b/express/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js

--- a/express/entry.sh
+++ b/express/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node index.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node index.js
 fi
+

--- a/express/entry.sh
+++ b/express/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -31,7 +34,7 @@ then
   fi
 elif [[ -n "$AGENT_LOCAL" ]]
 then
-  cp /opt/contrast/node_contrast*.tgz .
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/express/entry.sh
+++ b/express/entry.sh
@@ -29,6 +29,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz .
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/fastify/entry.sh
+++ b/fastify/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js

--- a/fastify/entry.sh
+++ b/fastify/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node server.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node server.js
 fi
+

--- a/fastify/entry.sh
+++ b/fastify/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/hapi18/entry.sh
+++ b/hapi18/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js

--- a/hapi18/entry.sh
+++ b/hapi18/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node server.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node server.js
 fi
+

--- a/hapi18/entry.sh
+++ b/hapi18/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/hapi19/entry.sh
+++ b/hapi19/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js

--- a/hapi19/entry.sh
+++ b/hapi19/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node server.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node server.js
 fi
+

--- a/hapi19/entry.sh
+++ b/hapi19/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/koa/entry.sh
+++ b/koa/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js

--- a/koa/entry.sh
+++ b/koa/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node index.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node index.js
 fi
+

--- a/koa/entry.sh
+++ b/koa/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/kraken/entry.sh
+++ b/kraken/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js

--- a/kraken/entry.sh
+++ b/kraken/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node server.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node server.js
 fi
+

--- a/kraken/entry.sh
+++ b/kraken/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/loopback/entry.sh
+++ b/loopback/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node server/server.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server/server.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node server/server.js
 fi
+

--- a/loopback/entry.sh
+++ b/loopback/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server/server.js

--- a/loopback/entry.sh
+++ b/loopback/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true

--- a/restify/entry.sh
+++ b/restify/entry.sh
@@ -1,15 +1,12 @@
 #! /bin/bash -e
-# `CONFIG` - name of configuration file in s3
-#
 # 2 modes:
 # 1: agent from mounted volume
-#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
 # 2: agent-less
 
-if [[ -n "$AGENT" ]];
+if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
+  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js

--- a/restify/entry.sh
+++ b/restify/entry.sh
@@ -1,50 +1,20 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 4 modes:
-# 1: agent from artifactory
+# 2 modes:
+# 1: agent from mounted volume
+#  - `AGENT` - boolean, will mount a dir to `/opt/contrast` to copy agent
 #  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT_VERSION` - e.g. 2.11.0
-#  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
-# 2: agent from s3 bucket:
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-#  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent from mounted volume
-#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
-# 4: agent-less
+# 2: agent-less
 
 if [[ -n "$AGENT" ]];
 then
-  echo "Downloading Node Agent: $AGENT from s3://node-agents"
-  aws s3 cp "s3://node-agents/$AGENT" node-agent.tgz
-elif [[ -n "$AGENT_VERSION" && -n "$AGENT_HASH" ]];
-then
-  AGENT_ARTIFACT_URL=https://contrastsecurity.jfrog.io/contrastsecurity/node-agent-staging/$AGENT_VERSION/$AGENT_HASH/node_contrast-$AGENT_VERSION.tgz
-  echo "Downloading Node Agent: $AGENT_ARTIFACT_URL"
-  responseCode=$(curl -L --silent \
-    --output node-agent.tgz \
-    -H "Authorization: Bearer $CONTRAST_ARTIFACTORY_ACCESS_TOKEN" \
-    -X GET "$AGENT_ARTIFACT_URL" \
-    --write-out "%{http_code}" )
-
-  if [[ ${responseCode} -ne 200 ]];
-  then
-    echo "Unable to download node agent - response code: $responseCode"
-    exit 1
-  fi
-elif [[ -n "$AGENT_LOCAL" ]]
-then
   cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
-else
-  echo "Running app in agent-less mode"
-  AGENT_LESS=true
-fi
-
-if [[ -n "$AGENT_LESS" ]];
-then
-  HOST=0.0.0.0 node index.js
-else
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
   HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js
+else
+  echo "Running app in agent-less mode"
+  HOST=0.0.0.0 node index.js
 fi
+

--- a/restify/entry.sh
+++ b/restify/entry.sh
@@ -1,14 +1,17 @@
 #! /bin/bash -e
 # `CONFIG` - name of configuration file in s3
 #
-# 3 modes:
+# 4 modes:
 # 1: agent from artifactory
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT_VERSION` - e.g. 2.11.0
 #  - `AGENT_HASH` e.g. 20200220-2232.9aa9d178
 # 2: agent from s3 bucket:
+#  - `CONFIG` - which config from s3://node-agent-configs to use
 #  - `AGENT` - name of .tgz in s3://node-agents
-# 3: agent-less
-#  - only env var needed is `CONFIG`
+# 3: agent from mounted volume
+#  - `AGENT_LOCAL` - boolean, will mount a dir to `/opt/contrast` to copy agent
+# 4: agent-less
 
 if [[ -n "$AGENT" ]];
 then
@@ -29,6 +32,9 @@ then
     echo "Unable to download node agent - response code: $responseCode"
     exit 1
   fi
+elif [[ -n "$AGENT_LOCAL" ]]
+then
+  cp /opt/contrast/node_contrast*.tgz ./node-agent.tgz
 else
   echo "Running app in agent-less mode"
   AGENT_LESS=true


### PR DESCRIPTION
Adds `AGENT_LOCAL` as another option for mounting a local volume to container(must be /opt/contrast) to install agent.

This PR, will show it in action: https://github.com/Contrast-Security-Inc/node-screener-service/pull/5