### PR TITLE
don't npm install agent

### DIFF
--- a/express/entry.sh
+++ b/express/entry.sh
@@ -6,10 +6,9 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap index.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node index.js

--- a/fastify/entry.sh
+++ b/fastify/entry.sh
@@ -6,10 +6,9 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap server.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node server.js

--- a/hapi18/entry.sh
+++ b/hapi18/entry.sh
@@ -6,10 +6,10 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
   npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap server.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node server.js

--- a/hapi19/entry.sh
+++ b/hapi19/entry.sh
@@ -6,10 +6,9 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap server.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node server.js

--- a/kraken/entry.sh
+++ b/kraken/entry.sh
@@ -6,10 +6,9 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap server.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node server.js

--- a/loopback/entry.sh
+++ b/loopback/entry.sh
@@ -6,10 +6,9 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap server/server.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap server/server.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node server/server.js

--- a/restify/entry.sh
+++ b/restify/entry.sh
@@ -6,10 +6,9 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
-  cp /opt/contrast/node-agent.tgz ./node-agent.tgz
+  pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
   aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  npm install node-agent.tgz
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r node_contrast/bootstrap index.js
+  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap index.js
 else
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node index.js


### PR DESCRIPTION
I didn't test all of these.  But I did sanity check with fastify that the agent still started (and had already done so with express).  I also added some timing log statements at the first line in the script and just before executing the agent to check how long that gap was - I ran with the old and new way twice:

```
old way:
pm debug start 1603396062
pm debug starting agent 1603396110

pm debug start 1603396183
pm debug starting agent 1603396228

new way:
pm debug start 1603396347
pm debug start agent 1603396350

pm debug start 1603396413
pm debug start agent 1603396416
```

so 3 seconds vs. ~45 seconds.