### PR TITLE
NODE-1138: point to @contrast/test-bench-utils in node_modules

### DIFF
--- a/express/vulnerabilities/cspHeaderInsecure/views/index.ejs
+++ b/express/vulnerabilities/cspHeaderInsecure/views/index.ejs
@@ -1,1 +1,1 @@
-<% include ../../../../test-bench-utils/public/views/cspHeaderInsecure.ejs %>
+<% include ../../../node_modules/@contrast/test-bench-utils/public/views/cspHeaderInsecure.ejs %>


### PR DESCRIPTION
Pointing to installed view, not the one in top-level monorepo.