### PR TITLE
Node 1254 screener env var support

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,10 +1,5 @@
 ARG node_version=12
 FROM node:$node_version
-RUN apt-get update && apt-get install -y python3
-RUN curl -sO https://bootstrap.pypa.io/get-pip.py
-RUN python3 get-pip.py
-
-RUN pip install awscli
 
 WORKDIR /app
 COPY . .

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -4,7 +4,7 @@ if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
   # agent from mounted volume
   pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
-  # agent configuration is done via env vars or mounted contrast_security.yaml
+  # agent configuration from mounted volume or env vars
   HOST=0.0.0.0 node -r /opt/contrast/package/bootstrap .
 else
   # 2: agent-less

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -1,15 +1,13 @@
 #! /bin/bash -e
-# 2 modes:
-# 1: agent from mounted volume
-#  - `CONFIG` - which config from s3://node-agent-configs to use
-# 2: agent-less
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
+  # agent from mounted volume
   pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
-  aws s3 cp "s3://node-agent-configs/$CONFIG" contrast_security.yaml
-  HOST=0.0.0.0 DEBUG="contrast:*" node -r /opt/contrast/package/bootstrap .
+  # agent configuration is done via env vars or mounted contrast_security.yaml
+  HOST=0.0.0.0 node -r /opt/contrast/package/bootstrap .
 else
+  # 2: agent-less
   echo "Running app in agent-less mode"
   HOST=0.0.0.0 node .
 fi


### PR DESCRIPTION
Reintroducing this mainly because of the fact that these images won't build due to the python install failures.