### PR TITLE
remove python/aws install

### DIFF
--- a/loopback4/Dockerfile
+++ b/loopback4/Dockerfile
@@ -1,11 +1,5 @@
 ARG node_version=12
 FROM node:$node_version
-RUN apt-get update && apt-get install -y python3
-RUN curl -sO https://bootstrap.pypa.io/get-pip.py
-RUN python3 get-pip.py
-
-RUN pip install awscli
-
 WORKDIR /app
 COPY . .
 RUN npm ci --unsafe-perm


### PR DESCRIPTION
I forgot to update this framework-local Dockerfile when removing python/aws deps from images.

Tested running screener against locally-built running container in Node 12 Assess mode:
```
NODE_CONFIG_DIR=./test/screener/config SCREENER_APP_URL=http://localhost:3000 SCREENER_RMQ_PASSWORD=guest SCREENER_RMQ_USERNAME=guest SCREENER_RMQ_HOSTNAME=localhost SCREENER_RMQ_PORT=5672 ./node_modules/.bin/mocha test/screener/apps/loopback4/assess/12.test.js

  loopback4:assess:12                                                                                                                                          
    [autocomplete-missing/unsafe] GET /autocompleteMissing                                                                                                     
      ✓ application returns a response (321ms)                                                                                                                 
      ✓ finding is reported (992ms)                                                                                                                            
      ✓ observed route is reported                                                                                                                             
      ✓ activity message was sent with all required fields                                                                                                     
 . . .
 
   [xxssprotection-header-disabled/unsafe] GET /xssProtectionHeaderDisabled
      ✓ application returns a response
      ✓ finding is reported
      ✓ observed route is reported
      ✓ activity message was sent with all required fields


   411 passing (3s)
```