### PR TITLE
NODE 1275: Kraken-js 2.3

### DIFF
--- a/kraken/index.js
+++ b/kraken/index.js
@@ -36,6 +36,15 @@ const options = {
      * `confit` (https://github.com/krakenjs/confit/) configuration object.
      */
     next(null, config);
+  },
+  onKrakenMount(app, options) {
+    app.use('/foo', (req, res) => {
+      res.send('hi!');
+    });
+    app.on('start', function() {
+      console.log('Application ready to serve requests.');
+      console.log('Environment: %s', app.kraken.get('env:env'));
+    });
   }
 };
 
@@ -44,10 +53,3 @@ app.locals.navRoutes = navRoutes;
 app.locals.currentYear = new Date().getFullYear();
 app.use(layouts);
 app.use(kraken(options));
-app.use('/foo', (req, res) => {
-  res.send('hi!');
-});
-app.on('start', function() {
-  console.log('Application ready to serve requests.');
-  console.log('Environment: %s', app.kraken.get('env:env'));
-});

--- a/kraken/package-lock.json
+++ b/kraken/package-lock.json
@@ -1243,6 +1243,11 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1752,12 +1757,9 @@
       }
     },
     "caller": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/caller/-/caller-0.0.1.tgz",
-      "integrity": "sha1-83odbqEOgp2UchrimpC7T7Uqt2c=",
-      "requires": {
-        "tape": "~2.3.2"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
+      "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU="
     },
     "callsites": {
       "version": "3.1.0",
@@ -2075,11 +2077,18 @@
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
     "compressible": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
-      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
       "requires": {
-        "mime-db": ">= 1.40.0 < 2"
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.46.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+          "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
+        }
       }
     },
     "compression": {
@@ -2136,49 +2145,6 @@
         "shortstop": "^1.0.1",
         "shortstop-handlers": "^1.0.0",
         "shush": "^1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "caller": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
-          "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU="
-        },
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-        },
-        "shortstop": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/shortstop/-/shortstop-1.0.3.tgz",
-          "integrity": "sha1-1Ddpw2/ufiCjub/S0IeJNf+G58Y=",
-          "requires": {
-            "async": "~0.2.10",
-            "core-util-is": "~1.0.1"
-          },
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-            }
-          }
-        },
-        "shortstop-handlers": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/shortstop-handlers/-/shortstop-handlers-1.0.1.tgz",
-          "integrity": "sha1-B1WstmBMdsnA52qelD+TeQurHcQ=",
-          "requires": {
-            "caller": "^1.0.1",
-            "core-util-is": "^1.0.1",
-            "glob": "^7.0.5"
-          }
-        }
       }
     },
     "console-control-strings": {
@@ -2213,19 +2179,12 @@
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
     "cookie-parser": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
       "requires": {
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        }
       }
     },
     "cookie-signature": {
@@ -3003,20 +2962,15 @@
         "path-to-regexp": "^1.1.1"
       },
       "dependencies": {
-        "caller": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
-          "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU="
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "requires": {
             "isarray": "0.0.1"
           }
@@ -3024,29 +2978,29 @@
       }
     },
     "express-session": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.16.2.tgz",
-      "integrity": "sha512-oy0sRsdw6n93E9wpCNWKRnSsxYnSDX9Dnr9mhZgqUEEorzcq5nshGYSZ4ZReHFhKQ80WI5iVUUSPW7u3GaKauw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.17.1.tgz",
+      "integrity": "sha512-UbHwgqjxQZJiWRTMyhvWGvjBQduGCSBDhhZXYenziMFjxst5rMV+aJZ6hKPHZnPyHGsrqRICxtX8jtEbm/z36Q==",
       "requires": {
-        "cookie": "0.3.1",
+        "cookie": "0.4.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "~2.0.0",
         "on-headers": "~1.0.2",
         "parseurl": "~1.3.3",
-        "safe-buffer": "5.1.2",
+        "safe-buffer": "5.2.0",
         "uid-safe": "~2.1.5"
       },
       "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
           "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
         }
       }
     },
@@ -3299,9 +3253,9 @@
       }
     },
     "formidable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -5486,9 +5440,9 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "kraken-js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/kraken-js/-/kraken-js-2.2.0.tgz",
-      "integrity": "sha1-a16e1AdP59HGsL3PCpCqgn1SKvg=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kraken-js/-/kraken-js-2.3.0.tgz",
+      "integrity": "sha512-etX75OAtXSyMDQernDHMc9iQ0HzilVI/MWdtztikU2s4qpTbvhQqlBLzK+EHdi6wl9+5NGfTSTwfUIaM2vrt0w==",
       "requires": {
         "bluebird": "^3.4.7",
         "body-parser": "^1.12.2",
@@ -5512,37 +5466,6 @@
         "shortstop-handlers": "^1.0.0",
         "shortstop-resolve": "^1.0.1",
         "shush": "^1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-        },
-        "caller": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caller/-/caller-1.0.1.tgz",
-          "integrity": "sha1-uFGGD3Dhlds9J3OVqhp+I+ow7PU="
-        },
-        "shortstop": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/shortstop/-/shortstop-1.0.3.tgz",
-          "integrity": "sha1-1Ddpw2/ufiCjub/S0IeJNf+G58Y=",
-          "requires": {
-            "async": "~0.2.10",
-            "core-util-is": "~1.0.1"
-          }
-        },
-        "shortstop-handlers": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/shortstop-handlers/-/shortstop-handlers-1.0.1.tgz",
-          "integrity": "sha1-B1WstmBMdsnA52qelD+TeQurHcQ=",
-          "requires": {
-            "caller": "^1.0.1",
-            "core-util-is": "^1.0.1",
-            "glob": "^7.0.5"
-          }
-        }
       }
     },
     "latest-version": {
@@ -5732,20 +5655,13 @@
       }
     },
     "meddleware": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/meddleware/-/meddleware-3.0.3.tgz",
-      "integrity": "sha1-FCUlCzQBB9cCU2iUH65zzV5zGSU=",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/meddleware/-/meddleware-3.0.4.tgz",
+      "integrity": "sha512-Y1+AoNwmuDuIUAtmvYyrY21dmDm2Pz6hSPE+e19dfE3nO4cvKGNaaklLhhwqhQegQZl6bqQTLmdV8tqqCK4K7g==",
       "requires": {
-        "caller": "0.0.1",
-        "core-util-is": "^1.0.1",
-        "debuglog": "0.0.4"
-      },
-      "dependencies": {
-        "debuglog": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.4.tgz",
-          "integrity": "sha1-DnBfuUnwhaoKpNczNkBmHQYP7hc="
-        }
+        "caller": "1.0.1",
+        "core-util-is": "^1.0.2",
+        "debuglog": "1.0.1"
       }
     },
     "media-typer": {
@@ -5910,15 +5826,22 @@
       }
     },
     "morgan": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
-      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
       "requires": {
-        "basic-auth": "~2.0.0",
+        "basic-auth": "~2.0.1",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
+        "depd": "~2.0.0",
         "on-finished": "~2.3.0",
-        "on-headers": "~1.0.1"
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "ms": {
@@ -7523,6 +7446,32 @@
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
+    "shortstop": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/shortstop/-/shortstop-1.0.3.tgz",
+      "integrity": "sha1-1Ddpw2/ufiCjub/S0IeJNf+G58Y=",
+      "requires": {
+        "async": "~0.2.10",
+        "core-util-is": "~1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        }
+      }
+    },
+    "shortstop-handlers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/shortstop-handlers/-/shortstop-handlers-1.0.1.tgz",
+      "integrity": "sha1-B1WstmBMdsnA52qelD+TeQurHcQ=",
+      "requires": {
+        "caller": "^1.0.1",
+        "core-util-is": "^1.0.1",
+        "glob": "^7.0.5"
+      }
+    },
     "shortstop-resolve": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/shortstop-resolve/-/shortstop-resolve-1.0.1.tgz",
@@ -7530,6 +7479,16 @@
       "requires": {
         "caller": "0.0.1",
         "resolve": "^1.0.0"
+      },
+      "dependencies": {
+        "caller": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/caller/-/caller-0.0.1.tgz",
+          "integrity": "sha1-83odbqEOgp2UchrimpC7T7Uqt2c=",
+          "requires": {
+            "tape": "~2.3.2"
+          }
+        }
       }
     },
     "shush": {
@@ -7541,6 +7500,14 @@
         "strip-json-comments": "~0.1.1"
       },
       "dependencies": {
+        "caller": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/caller/-/caller-0.0.1.tgz",
+          "integrity": "sha1-83odbqEOgp2UchrimpC7T7Uqt2c=",
+          "requires": {
+            "tape": "~2.3.2"
+          }
+        },
         "strip-json-comments": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",

--- a/kraken/package.json
+++ b/kraken/package.json
@@ -29,7 +29,7 @@
     "express": "^4.12.2",
     "express-async-errors": "^3.1.1",
     "express-ejs-layouts": "^2.5.0",
-    "kraken-js": "^2.0.0",
+    "kraken-js": "^2.3.0",
     "lodash": "^4.17.19"
   },
   "devDependencies": {


### PR DESCRIPTION
- Bump kraken-js to 2.3
- Implement new onKrakenMount feature

I'm pretty sure we're good to bump this. Not much has changed in 2.3: https://github.com/krakenjs/kraken-js/compare/v2.0.0...v2.3.0 I used the new onKrakenMount feature to make sure but we don't have to keep it. Tested on new screener with Node 10, 12, and 14 with all passing.