### PR TITLE
Push all tagged images to ECR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,4 +36,4 @@ jobs:
           cd $ECR_REPOSITORY
           ../scripts/copy_scripts.sh
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG-$NODE_VERSION -t $ECR_REGISTRY/$ECR_REPOSITORY:latest-$NODE_VERSION --build-arg node_version=$NODE_VERSION .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY
+          docker push -a $ECR_REGISTRY/$ECR_REPOSITORY


### PR DESCRIPTION
Looks like older Docker versions pushed all tagged images by default but now you have to specify the tag unless using --all-tags (-a) option