### PR TITLE
NODE 1428: Adapt express and koa to use HTTP/2

### DIFF
--- a/express/index.js
+++ b/express/index.js
@@ -34,7 +34,7 @@ const pem = require('pem');
 const app = express();
 const { PORT = 3000, HOST = 'localhost', SSL, CLUSTER, HTTP2 } = process.env;
 const isHttps = SSL === '1' ? true : false;
-const isHttp2 = HTTP2 === 'true' ? true : false;
+const isHttp2 = HTTP2 === '1' ? true : false;
 require('./app').setup(app);
 
 const listener = function listener() {
@@ -47,25 +47,23 @@ const listener = function listener() {
 };
 
 function createServer() {
-  pem.createCertificate({ days : 1, selfSigned : true }, (err, keys) => {
-    if (err) {
-      throw err;
-    }
-    const options = { key: keys.serviceKey, cert: keys.certificate }
-    server(options).listen(PORT, HOST, listener);
-  })
-}
-
-function server(options) {
-  let server;
-  if (isHttps) {
-    server = https.createServer(options, app);
-  } else if (isHttp2) {
-    server = http2.createServer(options, app);
+  if (!isHttps && !isHttp2) {
+    http.createServer(app).listen(PORT, HOST, listener);
   } else {
-    server = http.createServer(app);
+    pem.createCertificate({ days : 1, selfSigned : true }, (err, keys) => {
+      let server;
+      if (err) {
+        throw err;
+      }
+      const options = { key: keys.serviceKey, cert: keys.certificate }
+      if (isHttps) {
+        server = https.createServer(options, app);
+      } else if (isHttp2) {
+        server = http2.createServer(options, app);
+      }
+      server.listen(PORT, HOST, listener);
+    })
   }
-  return server
 }
 
 if (CLUSTER) {

--- a/express/index.js
+++ b/express/index.js
@@ -27,17 +27,19 @@ const express = require('express');
  */
 require('express-async-errors');
 const http = require('http');
+const http2 = require('spdy');
 const https = require('https');
 const pem = require('pem');
 
 const app = express();
-const { PORT = 3000, HOST = 'localhost', SSL, CLUSTER } = process.env;
+const { PORT = 3000, HOST = 'localhost', SSL, CLUSTER, HTTP2 } = process.env;
 const isHttps = SSL === '1' ? true : false;
+const isHttp2 = HTTP2 === 'true' ? true : false;
 require('./app').setup(app);
 
 const listener = function listener() {
   const { address, port } = this.address();
-  const protocol = isHttps ? 'https' : 'http';
+  const protocol = (isHttps || isHttp2) ? 'https' : 'http';
   const stop = Date.now();
   /* eslint-disable no-console */
   console.log(`startup time: ${stop - start}`);
@@ -45,17 +47,25 @@ const listener = function listener() {
 };
 
 function createServer() {
-  /* Start Server based on protocol */
-  isHttps
-    ? pem.createCertificate({ days: 1, selfSigned: true }, (err, keys) => {
-        if (err) {
-          throw err;
-        }
-        https
-          .createServer({ key: keys.serviceKey, cert: keys.certificate }, app)
-          .listen(PORT, HOST, listener);
-      })
-    : http.createServer(app).listen(PORT, HOST, listener);
+  pem.createCertificate({ days : 1, selfSigned : true }, (err, keys) => {
+    if (err) {
+      throw err;
+    }
+    const options = { key: keys.serviceKey, cert: keys.certificate }
+    server(options).listen(PORT, HOST, listener);
+  })
+}
+
+function server(options) {
+  let server;
+  if (isHttps) {
+    server = https.createServer(options, app);
+  } else if (isHttp2) {
+    server = http2.createServer(options, app);
+  } else {
+    server = http.createServer(app);
+  }
+  return server
 }
 
 if (CLUSTER) {

--- a/express/package-lock.json
+++ b/express/package-lock.json
@@ -2778,6 +2778,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
     },
+    "detect-node": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.5.tgz",
+      "integrity": "sha512-qi86tE6hRcFHy8jI1m2VG+LaPUR1LhqDa5G8tVjuUXmOrpuAgqsA1pN0+ldgr3aKUH+QLI9hCY/OcRYisERejw=="
+    },
     "dicer": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
@@ -3950,6 +3955,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "optional": true
     },
+    "handle-thing": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
+    },
     "handlebars": {
       "version": "4.7.7",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
@@ -4081,6 +4091,41 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
     },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -4099,6 +4144,11 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc="
     },
     "http-errors": {
       "version": "1.7.2",
@@ -6434,6 +6484,11 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -7286,6 +7341,11 @@
       "requires": {
         "isobject": "^3.0.1"
       }
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -8436,6 +8496,11 @@
         "xmlchars": "^2.2.0"
       }
     },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -8841,6 +8906,84 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+    },
+    "spdy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
+      "requires": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "spdy-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
+      "requires": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        }
+      }
     },
     "split-string": {
       "version": "3.1.0",
@@ -9977,6 +10120,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webidl-conversions": {

--- a/express/package.json
+++ b/express/package.json
@@ -39,6 +39,7 @@
     "multer": "^1.4.1",
     "newrelic": "^6.1.0",
     "pem": "^1.14.2",
+    "spdy": "^4.0.2",
     "sqlite3": "^5.0.0"
   },
   "devDependencies": {

--- a/koa/index.js
+++ b/koa/index.js
@@ -6,6 +6,8 @@ const Router = process.env.LEGACY_ROUTER
   : require('@koa/router');
 const app = new Koa();
 const router = new Router();
+const http2 = require('http2');
+const pem = require('pem');
 const render = require('koa-ejs');
 const serve = require('koa-static');
 const mount = require('koa-mount');
@@ -13,8 +15,8 @@ const bodyParser = require('koa-bodyparser');
 const cookieParser = require('koa-cookie');
 const { navRoutes } = require('@contrast/test-bench-utils');
 
-const { PORT = 3000, HOST = 'localhost' } = process.env;
-
+const { PORT = 3000, HOST = 'localhost', HTTP2 } = process.env;
+const isHttp2 = HTTP2 === 'true' ? true : false;
 // setup static file serving
 app.use(mount('/assets', serve(`${__dirname}/public`)));
 
@@ -48,8 +50,31 @@ navRoutes.forEach(({ base }) => {
 app.use(router.routes());
 app.use(router.allowedMethods());
 
-app.listen(PORT, HOST, function listener() {
+function listener() {
   const { address, port } = this.address();
+  const protocol = isHttp2 ? 'https' : 'http';
   // eslint-disable-next-line no-console
-  console.log('Server listening on http://%s:%d', address, port);
-});
+  console.log('Server listening on %s://%s:%d', protocol, address, port);
+};
+
+function server(options) {
+  let server;
+  if (isHttp2) {
+    server = http2.createSecureServer(options, app.callback());
+  } else {
+    server = app;
+  }
+  return server
+}
+
+function createServer() {
+  pem.createCertificate({ days : 1, selfSigned : true }, (err, keys) => {
+    if (err) {
+      throw err;
+    }
+    const options = { key: keys.serviceKey, cert: keys.certificate }
+    server(options).listen(PORT, HOST, listener);
+  })
+}
+
+createServer();

--- a/koa/package-lock.json
+++ b/koa/package-lock.json
@@ -1966,6 +1966,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "chokidar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
@@ -2389,6 +2394,11 @@
         }
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -2711,6 +2721,11 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "es6-promisify": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
+      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -6031,6 +6046,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6840,6 +6865,27 @@
       "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
       "requires": {
         "isarray": "0.0.1"
+      }
+    },
+    "pem": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.14.4.tgz",
+      "integrity": "sha512-v8lH3NpirgiEmbOqhx0vwQTxwi0ExsiWBGYh0jYNq7K6mQuO4gI6UEFlr6fLAdv9TPXRt6GqiwE37puQdIDS8g==",
+      "requires": {
+        "es6-promisify": "^6.0.0",
+        "md5": "^2.2.1",
+        "os-tmpdir": "^1.0.1",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "performance-now": {

--- a/koa/package.json
+++ b/koa/package.json
@@ -34,7 +34,8 @@
     "koa-multer": "^1.0.2",
     "koa-router": "^8.0.8",
     "koa-static": "^5.0.0",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "pem": "^1.14.4"
   },
   "devDependencies": {
     "@contrast/eslint-config": "^2.0.0",


### PR DESCRIPTION
There was some confusion because the ticket specifies: 

> Express-test-bench should be adapted to use the standard library http2
> Koa-test-bench should be adapted to use the spdy library

but according to some of the documentation included in that same ticket: https://www.perimeterx.com/tech-blog/2019/http2/
> We need to have couple of changes if we want to apply HTTP/2 on our Express server. We can’t use the native HTTP/2 library directly, so we will use the spdy library. 

So I'm assuming it was a typo and that Koa should be adapted to use the native HTTP/2 library and Express should use Spdy. It doesn't look like Express will be compatible with the native library any time soon: https://github.com/expressjs/express/issues/3388
