### PR TITLE
NODE 1587: Fix screener regression

### DIFF
--- a/express/vulnerabilities/unsafeFileUpload/index.js
+++ b/express/vulnerabilities/unsafeFileUpload/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const express = require('express');
-const { get } = require('lodash');
 const path = require('path');
 const multer = require('multer');
 
@@ -20,10 +19,10 @@ router.get('/', function(req, res) {
   });
 });
 
-sinkData.forEach(({ method, params, uri, sink, key }) => {
+sinkData.forEach(({ method, params, uri, sinks, key }) => {
   router[method](uri, upload.single('file'), async (req, res) => {
     const inputs = utils.getInput(req, key, params);
-    const result = await sink(inputs); // doesn't really do anything
+    const result = await sinks.unsafe(inputs); // doesn't really do anything
     res.send(result);
   });
 });

--- a/fastify/routes/unsafeFileUpload.js
+++ b/fastify/routes/unsafeFileUpload.js
@@ -16,7 +16,7 @@ module.exports = async function route(fastify, options) {
     return reply;
   });
 
-  sinkData.forEach(({ method, params, url, sink, key }) => {
+  sinkData.forEach(({ method, params, url, sinks, key }) => {
     fastify[method](url, async (req, reply) => {
       const inputs = utils.getInput(req, key, params);
       // We sometimes use these routes just to test UFU and there is no input
@@ -24,7 +24,7 @@ module.exports = async function route(fastify, options) {
       if (isEmpty(inputs)) {
         return 'done';
       } else {
-        return await sink(inputs);
+        return await sinks.unsafe(inputs);
       }
     });
   });

--- a/koa/routes/unsafeFileUpload.js
+++ b/koa/routes/unsafeFileUpload.js
@@ -1,5 +1,4 @@
 const multer = require('koa-multer');
-const { get } = require('lodash');
 const path = require('path');
 
 const { routes, utils } = require('@contrast/test-bench-utils');
@@ -20,10 +19,10 @@ module.exports = ({ router }) => {
     })
   );
 
-  sinkData.forEach(({ method, params, url, sink }) => {
+  sinkData.forEach(({ method, params, url, sinks }) => {
     router[method](url, upload.single('file'), async (ctx, next) => {
       const inputs = utils.getInput(ctx, 'req.body', params); // multer puts it on `req`, elsewhere it's `request`
-      const result = await sink(inputs); // doesn't really do anything
+      const result = await sinks.unsafe(inputs); // doesn't really do anything
       ctx.body = result;
     });
   });

--- a/kraken/controllers/unsafeFileUpload/index.js
+++ b/kraken/controllers/unsafeFileUpload/index.js
@@ -11,10 +11,10 @@ module.exports = (router) => {
     res.render('unsafeFileUpload', model);
   });
 
-  model.sinkData.forEach(({ method, uri, sink, key, params }) => {
+  model.sinkData.forEach(({ method, uri, sinks, key, params }) => {
     router[method](uri, async (req, res) => {
       const inputs = utils.getInput(req, key, params);
-      const result = await sink(inputs); // doesn't really do anything
+      const result = await sinks.unsafe(inputs); // doesn't really do anything
       res.send(result);
     });
   });

--- a/restify/vulnerabilities/unsafeFileUpload/index.js
+++ b/restify/vulnerabilities/unsafeFileUpload/index.js
@@ -10,19 +10,19 @@ const router = new Router();
 const sinkData = utils.getSinkData('unsafeFileUpload', 'restify');
 const routeMeta = utils.getRouteMeta('unsafeFileUpload');
 
-router.get('/', function (req, res) {
+router.get('/', function(req, res) {
   res.render(path.resolve(__dirname, 'views', 'index'), {
     ...routeMeta,
-    sinkData,
+    sinkData
   });
 });
 
-sinkData.forEach(({ method, params, uri, sink, key }) => {
+sinkData.forEach(({ method, params, uri, sinks, key }) => {
   router[method](
     uri,
     wrapHandler(async (req, res) => {
       const inputs = utils.getInput(req, key, params);
-      const result = await sink(inputs); // doesn't really do anything
+      const result = await sinks.unsafe(inputs); // doesn't really do anything
       res.send(result);
     })
   );


### PR DESCRIPTION
The errors this change addresses:
```
express:assess:12   
     [reflected-xss/unsafe] POST /unsafeFileUpload/body/upload
       finding is reported:
   AssertionError: finding was not reported for reflected-xss: expected null to be an object
    at Context.<anonymous> (test/screener/utils/assertions/assess-finding.js:21:31)

express:monitor:10
     [reflected-xss/unsafe] POST /unsafeFileUpload/body/upload              
       exploit is reported:

    AssertionError: attack did not exploit instead: 3: expected 3 to equal 2
    + expected - actual
                                           
    -3                                                                                   
    +2                            
```
https://github.com/Contrast-Security-OSS/NodeTestBenches/commit/2c3492b299daf79de92888908596ab57d6b5cf0e replaced the "sink" property in SinkData with "sinks: sinkObj". The controllerFactory files were refactored to account for this but unsafeFileUpload is the odd man out and has its own special definition in its own file for each application and they were still trying to use the old "sink" property. This resulted in "sink is not a function" errors when running the app (with or without the agent). This change updates them. Hapi and Loopback have a different definition that doesn't use that property so we're not seeing the same error for those. The apps that have this error are Express, Fastify, Fastify3 (which the Fastify change applies to), Restify, Koa, and Kraken. I've built new Docker images with this change and uploaded them to ECR with the tag "jk-test" and the screener tests we expect to pass are passing.