### PR TITLE
Added an option to use the standalone rewriter with any app

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -3,6 +3,6 @@ FROM node:$node_version
 
 WORKDIR /app
 COPY . .
-RUN npm ci --production
+RUN npm ci
 RUN chmod +x entry.sh
 CMD ./entry.sh

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -2,8 +2,21 @@
 
 if [[ -f "/opt/contrast/node-agent.tgz" ]];
 then
+  npm config set offline
+    
   # agent from mounted volume
   pushd /opt/contrast && tar xzf ./node-agent.tgz && popd
+  node --version
+
+  # precompile code using the standalone rewriter
+  if [ "$PRECOMPILE" = true ] ; then
+    echo "Run npm install"  
+    npm install /opt/contrast/node-agent.tgz --verbose  
+
+    echo "Run npx contrast-transpile"
+    DEBUG=contrast:* npx contrast-transpile server.js
+  fi
+
   # agent configuration from mounted volume or env vars
   HOST=0.0.0.0 node -r /opt/contrast/package/bootstrap .
 else


### PR DESCRIPTION
`entry.sh` is executed in an environment with no network access and installing production-only dependencies was not enough to launch the rewriter.