### PR TITLE
Add Sails to the list of frameworks

### DIFF
--- a/test-bench-utils/lib/frameworks.js
+++ b/test-bench-utils/lib/frameworks.js
@@ -46,5 +46,6 @@ module.exports = {
     params: { method: 'get', key: 'params', param: '{input}' },
     body: { method: 'post', key: 'payload' },
     cookies: { method: 'post', key: 'state' }
-  }
+  },
+  sails: sharedMapping,
 };


### PR DESCRIPTION
In order to tests the new Sails app, this should be merged and released first, otherwise Sails has no routes. 