### PR TITLE
NODE-2543 Added more routes for MongoDB testing

### DIFF
--- a/test-bench-utils/lib/sinks/nosqlInjection/mongodb.js
+++ b/test-bench-utils/lib/sinks/nosqlInjection/mongodb.js
@@ -75,3 +75,73 @@ module.exports['mongodb.Collection.prototype.rename'] = async function rename(
 
   return `<pre>${escape(JSON.stringify(result.collectionName, null, 2))}</pre>`;
 };
+
+/**
+ * @param {Object} params
+ * @param {string} params.input user input string
+ * @param {Object} opts
+ * @param {boolean} [opts.safe] are we calling the sink safely?
+ * @param {boolean} [opts.noop] are we calling the sink as a noop?
+ */
+module.exports['mongodb.Collection.prototype.findOne'] = async function rename(
+  { input },
+  { safe = false, noop = false } = {}
+) {
+  if (noop) return 'NOOP';
+
+  const value = safe ? 'world' : input;
+  const db = await initDb();
+  const result = await db
+    .collection(MONGO_COLLECTION)
+    .findOne({ hello: value })
+    .catch((err) => {});
+
+  return `<pre>${escape(JSON.stringify(result, null, 2))}</pre>`;
+};
+
+/**
+ * @param {Object} params
+ * @param {string} params.input user input string
+ * @param {Object} opts
+ * @param {boolean} [opts.safe] are we calling the sink safely?
+ * @param {boolean} [opts.noop] are we calling the sink as a noop?
+ */
+module.exports['mongodb.Collection.prototype.insertMany'] = async function rename(
+  { input },
+  { safe = false, noop = false } = {}
+) {
+  if (noop) return 'NOOP';
+
+  const value = safe ? 'Cat Henry' : input;
+  const db = await initDb();
+  const result = await db
+    .collection(MONGO_COLLECTION)
+    .insertMany([{ hello: 'Shusia' }, { hello: value }, { hello: 'Simba' }])
+    .catch((err) => {});
+
+  return `<pre>${escape(JSON.stringify(result, null, 2))}</pre>`;
+};
+
+/**
+ * @param {Object} params
+ * @param {string} params.input user input string
+ * @param {Object} opts
+ * @param {boolean} [opts.safe] are we calling the sink safely?
+ * @param {boolean} [opts.noop] are we calling the sink as a noop?
+ */
+module.exports['mongodb.Collection.prototype.updateOne'] = async function rename(
+  { input },
+  { safe = false, noop = false } = {}
+) {
+  if (noop) return 'NOOP';
+
+  // In this example, the filter is SAFE, but the update object might not be
+  const value = safe ? 'Shusia' : input;
+  const db = await initDb();
+  const result = await db
+    .collection(MONGO_COLLECTION)
+    .updateOne({ hello: 'world' }, { $set: { hello: value }})
+    .catch((err) => {});
+
+  return `<pre>${escape(JSON.stringify(result, null, 2))}</pre>`;
+};

--- a/test-bench-utils/types/sinks/nosqlInjection/index.d.ts
+++ b/test-bench-utils/types/sinks/nosqlInjection/index.d.ts
@@ -11,6 +11,12 @@ declare const _exports: {
         safe?: boolean;
         noop?: boolean;
     }) => Promise<string>;
+    'mongodb.Collection.prototype.findOne': ({ input }: {
+        input: string;
+    }, { safe, noop }?: {
+        safe?: boolean;
+        noop?: boolean;
+    }) => Promise<string>;
     'aws-sdk.DynamoDB.DocumentClient.prototype.scan': ({ input }: {
         input: string;
     }, { safe, noop }?: {

--- a/test-bench-utils/types/sinks/nosqlInjection/mongodb.d.ts
+++ b/test-bench-utils/types/sinks/nosqlInjection/mongodb.d.ts
@@ -10,3 +10,9 @@ export function _mongodb_Collection_prototype_rename({ input }: {
     safe?: boolean;
     noop?: boolean;
 }): Promise<string>;
+export function _mongodb_Collection_prototype_findOne({ input }: {
+    input: string;
+}, { safe, noop }?: {
+    safe?: boolean;
+    noop?: boolean;
+}): Promise<string>;


### PR DESCRIPTION
I think there is no need to test the entire MongoDB API, but simply different types of collection methods, so that we can use the app to reproduce various behaviours (and TS reporting issues).