### PR TITLE
NODE-2635: Update Dockerfiles to be compatible with Bullseye

### DIFF
--- a/express/screener.sh
+++ b/express/screener.sh
@@ -20,15 +20,13 @@ rethinkdb --daemon
 echo "Starting MySQL"
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"
-# Disreagard the Access Denied messsage, the password was set and the privileges were flushed.
 
 # Run DynamoDB
 DYNAMODB_HOME="${DYNAMODB_HOME:=/opt/dynamodb}"

--- a/fastify/screener.sh
+++ b/fastify/screener.sh
@@ -20,15 +20,13 @@ rethinkdb --daemon
 echo "Starting MySQL"
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"
-# Disreagard the Access Denied messsage, the password was set and the privileges were flushed.
 
 # Run DynamoDB
 DYNAMODB_HOME="${DYNAMODB_HOME:=/opt/dynamodb}"

--- a/hapi18/screener.sh
+++ b/hapi18/screener.sh
@@ -20,15 +20,13 @@ rethinkdb --daemon
 echo "Starting MySQL"
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"
-# Disreagard the Access Denied messsage, the password was set and the privileges were flushed.
 
 # Run DynamoDB
 DYNAMODB_HOME="${DYNAMODB_HOME:=/opt/dynamodb}"

--- a/hapi19/screener.sh
+++ b/hapi19/screener.sh
@@ -20,15 +20,13 @@ rethinkdb --daemon
 echo "Starting MySQL"
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"
-# Disreagard the Access Denied messsage, the password was set and the privileges were flushed.
 
 # Run DynamoDB
 DYNAMODB_HOME="${DYNAMODB_HOME:=/opt/dynamodb}"

--- a/hapi20/screener.sh
+++ b/hapi20/screener.sh
@@ -20,15 +20,13 @@ rethinkdb --daemon
 echo "Starting MySQL"
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"
-# Disreagard the Access Denied messsage, the password was set and the privileges were flushed.
 
 # Run DynamoDB
 DYNAMODB_HOME="${DYNAMODB_HOME:=/opt/dynamodb}"

--- a/koa/screener.sh
+++ b/koa/screener.sh
@@ -20,15 +20,13 @@ rethinkdb --daemon
 echo "Starting MySQL"
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"
-# Disreagard the Access Denied messsage, the password was set and the privileges were flushed.
 
 # Run DynamoDB
 DYNAMODB_HOME="${DYNAMODB_HOME:=/opt/dynamodb}"

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,8 +1,8 @@
 ARG node_version=12
-FROM node:${node_version}-stretch
+FROM node:${node_version}-bullseye
 
 # Create the file repository configuration, import the repository signing key and install PostgreSQL & sudo
-RUN echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt update
 RUN apt install -y postgresql-10 postgresql-contrib-10 postgresql-client-10
@@ -20,7 +20,7 @@ EXPOSE 5432
 VOLUME  ["/etc/postgresql", "/var/log/postgresql", "/var/lib/postgresql"]
 
 # Install RethinkDB
-RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
+RUN echo "deb https://download.rethinkdb.com/repository/debian-bullseye bullseye main" > /etc/apt/sources.list.d/rethinkdb.list
 RUN wget -qO- https://download.rethinkdb.com/repository/raw/pubkey.gpg | sudo apt-key add -v - && apt-get update && apt-get install -y rethinkdb
 RUN rm -rf /var/lib/apt/lists/*
 VOLUME  ["/etc/rethinkdb", "/var/log/rethinkdb", "/var/lib/rethinkdb"]
@@ -29,10 +29,10 @@ EXPOSE 28015
 
 # Install MySQL Database
 ENV DEBIAN_FRONTEND="noninteractive"
-RUN wget http://repo.mysql.com/mysql-apt-config_0.8.13-1_all.deb
+RUN wget http://repo.mysql.com/mysql-apt-config_0.8.23-1_all.deb
 RUN apt update
-RUN apt install lsb-base lsb-release ./mysql-apt-config_0.8.13-1_all.deb
-RUN apt install mysql-server mysql-client -y
+RUN apt install lsb-base lsb-release ./mysql-apt-config_0.8.23-1_all.deb
+RUN apt install mariadb-server mariadb-client -y
 VOLUME ["/etc/mysql", "/var/lib/mysql"]
 
 EXPOSE 3306

--- a/scripts/Dockerfile-screener
+++ b/scripts/Dockerfile-screener
@@ -1,8 +1,8 @@
 ARG node_version=14
-FROM node:${node_version}-stretch
+FROM node:${node_version}-bullseye
 
 # Create the file repository configuration, import the repository signing key and install
-RUN echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN apt update
 RUN apt-get -y install sudo
@@ -17,18 +17,18 @@ VOLUME  ["/etc/postgresql", "/var/log/postgresql", "/var/lib/postgresql"]
 EXPOSE 5432
 
 # RethinkDB
-RUN echo "deb https://download.rethinkdb.com/repository/debian-stretch stretch main" > /etc/apt/sources.list.d/rethinkdb.list
+RUN echo "deb https://download.rethinkdb.com/repository/debian-bullseye bullseye main" > /etc/apt/sources.list.d/rethinkdb.list
 RUN wget -qO- https://download.rethinkdb.com/repository/raw/pubkey.gpg | sudo apt-key add -v - && apt-get update && apt-get install -y rethinkdb
 RUN rm -rf /var/lib/apt/lists/*
 VOLUME  ["/etc/rethinkdb", "/var/log/rethinkdb", "/var/lib/rethinkdb"]
 EXPOSE 28015
 
-# MySQL Database
+# Install MySQL Database
 ENV DEBIAN_FRONTEND="noninteractive"
-RUN wget http://repo.mysql.com/mysql-apt-config_0.8.13-1_all.deb
+RUN wget http://repo.mysql.com/mysql-apt-config_0.8.23-1_all.deb
 RUN apt update
-RUN apt install lsb-base lsb-release ./mysql-apt-config_0.8.13-1_all.deb
-RUN apt install mysql-server mysql-client -y
+RUN apt install lsb-base lsb-release ./mysql-apt-config_0.8.23-1_all.deb
+RUN apt install mariadb-server mariadb-client -y
 VOLUME ["/etc/mysql", "/var/lib/mysql"]
 EXPOSE 3306
 

--- a/scripts/entry.sh
+++ b/scripts/entry.sh
@@ -19,12 +19,11 @@ sudo -u postgres createdb "${PGDATABASE}"
 rethinkdb --daemon
 
 # Run MySQL (MariaDB)
-/etc/init.d/mysql start
+/etc/init.d/mariadb start
 MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-"password"}
 MYSQL_DATABASE=${MYSQL_DATABASE:-"testdb"}
 mysql --version
-mysql -e "UPDATE mysql.user SET authentication_string = PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User = 'root' AND Host = 'localhost';"
-mysql -e "update mysql.user set plugin = 'mysql_native_password' where User='root'"
+mysql -e "SET password for 'root'@'localhost' = PASSWORD('${MYSQL_ROOT_PASSWORD}');"
 mysql -uroot -e "drop database if exists $MYSQL_DATABASE"
 mysql -uroot -e "create database $MYSQL_DATABASE"
 mysql -e "FLUSH PRIVILEGES"


### PR DESCRIPTION
This is an offshoot of https://github.com/Contrast-Security-OSS/NodeTestBenches/pull/310 which caused the pipeline to fail: https://github.com/Contrast-Security-OSS/NodeTestBenches/actions/runs/3061326288 because there is no Docker image of Node18 built for Debian "Stretch". I don't think there will be since it's no longer LTS: https://www.debian.org/releases/stretch/ but I couldn't find anything confirming or denying that. Regardless, I think it's best to get off it and use the current LTS which is "Bullseye": https://www.debian.org/releases/bullseye/

The main problem with that is mysql-client and mysql-server aren't on anything later than "Stretch": https://packages.debian.org/stretch/mysql-server (available) v. https://packages.debian.org/bullseye/mysql-server (not available) so we need to change it to mariadb-client and mariadb-server which also required updating some of the mysql commands.

Tl;dr: Upgrading one thing required upgrading another thing that required upgrading another thing

I've tested both updated Dockerfiles locally and they build and run. I uploaded the v5 one to ECR and ran screener tests on it and they all pass.