### PR TITLE
NODE-2665: Use latest versions of Hapi 18, 19, and @Hapi/glue

### DIFF
--- a/hapi18/package-lock.json
+++ b/hapi18/package-lock.json
@@ -10,8 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@contrast/test-bench-utils": "^3.31.0",
-        "@hapi/glue": "^6.2.0",
-        "@hapi/hapi": "^18.4.0",
+        "@hapi/glue": "^8.0.0",
+        "@hapi/hapi": "^18.4.1",
         "@hapi/hoek": "^9.0.3",
         "@hapi/inert": "^5.2.2",
         "@hapi/vision": "^6.0.0",
@@ -1707,20 +1707,287 @@
       "deprecated": "Moved to 'npm install @sideway/formula'"
     },
     "node_modules/@hapi/glue": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-6.2.0.tgz",
-      "integrity": "sha512-pRDgmP+TqVRzHWIgrRep/Zigia/tTkaAG28HYCvzmwuEi1dg6+8/n3J3rJw39D4sjb74MsbQnuenYJ4Rq+8yuw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-8.0.0.tgz",
+      "integrity": "sha512-dqAQ401MTDpTUnPUtUZ/RIJOE+ROTjhq1YgPeuAVMYpoYlh55PNNJq6YBDBlye5VcF9uYtL1h3VnRMZz2NSlXw==",
       "dependencies": {
-        "@hapi/hapi": "18.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
+        "@hapi/hapi": "20.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       }
     },
-    "node_modules/@hapi/glue/node_modules/@hapi/hoek": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
-      "deprecated": "This version has been deprecated and is no longer supported or maintained"
+    "node_modules/@hapi/glue/node_modules/@hapi/accept": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+      "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/ammo": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+      "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/b64": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/boom": {
+      "version": "9.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/bounce": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+      "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/bourne": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/call": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+      "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/catbox": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+      "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/podium": "4.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/catbox-memory": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+      "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/content": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+      "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/cryptiles": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+      "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/hapi": {
+      "version": "20.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
+      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+      "dependencies": {
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.4",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "^5.1.1",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/heavy": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+      "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/iron": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/mimos": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/nigel": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+      "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/vise": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/pez": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+      "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+      "dependencies": {
+        "@hapi/b64": "5.x.x",
+        "@hapi/boom": "9.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/nigel": "4.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/podium": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/teamwork": "5.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/shot": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/somever": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+      "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+      "dependencies": {
+        "@hapi/bounce": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/statehood": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bounce": "2.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/cryptiles": "5.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/iron": "6.x.x",
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/subtext": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.4.tgz",
+      "integrity": "sha512-Y72moHhbRuO8kwBHFEnCRw7oOnhNh4Pl+aonxAze18jkyMpE4Gwz4lNID7ei8vd3lpXC2rKdkxXJgtfY+WttRw==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/content": "^5.0.2",
+        "@hapi/file": "2.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/pez": "^5.0.1",
+        "@hapi/wreck": "17.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/teamwork": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/vise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+      "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/wreck": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
+      "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+      "dependencies": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/bourne": "2.x.x",
+        "@hapi/hoek": "9.x.x"
+      }
     },
     "node_modules/@hapi/hapi": {
       "version": "18.4.1",
@@ -2012,6 +2279,23 @@
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
       "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "deprecated": "This version has been deprecated and is no longer supported or maintained"
+    },
+    "node_modules/@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "node_modules/@hapi/validate/node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
     },
     "node_modules/@hapi/vise": {
       "version": "3.1.1",
@@ -12129,19 +12413,275 @@
       "integrity": "sha512-UFbtbGPjstz0eWHb+ga/GM3Z9EzqKXFWIbSOFURU0A/Gku0Bky4bCk9/h//K2Xr3IrCfjFNhMm4jyZ5dbCewGA=="
     },
     "@hapi/glue": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-6.2.0.tgz",
-      "integrity": "sha512-pRDgmP+TqVRzHWIgrRep/Zigia/tTkaAG28HYCvzmwuEi1dg6+8/n3J3rJw39D4sjb74MsbQnuenYJ4Rq+8yuw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-8.0.0.tgz",
+      "integrity": "sha512-dqAQ401MTDpTUnPUtUZ/RIJOE+ROTjhq1YgPeuAVMYpoYlh55PNNJq6YBDBlye5VcF9uYtL1h3VnRMZz2NSlXw==",
       "requires": {
-        "@hapi/hapi": "18.x.x",
-        "@hapi/hoek": "8.x.x",
-        "@hapi/joi": "16.x.x"
+        "@hapi/hapi": "20.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/validate": "1.x.x"
       },
       "dependencies": {
-        "@hapi/hoek": {
-          "version": "8.5.1",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
-          "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+        "@hapi/accept": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/accept/-/accept-5.0.2.tgz",
+          "integrity": "sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/ammo": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/ammo/-/ammo-5.0.1.tgz",
+          "integrity": "sha512-FbCNwcTbnQP4VYYhLNGZmA76xb2aHg9AMPiy18NZyWMG310P5KdFGyA9v2rm5ujrIny77dEEIkMOwl0Xv+fSSA==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/b64": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
+          "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/boom": {
+          "version": "9.1.4",
+          "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
+          "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bounce": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",
+          "integrity": "sha512-JesW92uyzOOyuzJKjoLHM1ThiOvHPOLDHw01YV8yh5nCso7sDwJho1h0Ad2N+E62bZyz46TG3xhAi/78Gsct6A==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/bourne": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
+          "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
+        },
+        "@hapi/call": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/call/-/call-8.0.1.tgz",
+          "integrity": "sha512-bOff6GTdOnoe5b8oXRV3lwkQSb/LAWylvDMae6RgEWWntd0SHtkYbQukDHKlfaYtVnSAgIavJ0kqszF/AIBb6g==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/catbox": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/catbox/-/catbox-11.1.1.tgz",
+          "integrity": "sha512-u/8HvB7dD/6X8hsZIpskSDo4yMKpHxFd7NluoylhGrL6cUfYxdQPnvUp9YU2C6F9hsyBVLGulBd9vBN1ebfXOQ==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/podium": "4.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/catbox-memory": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/catbox-memory/-/catbox-memory-5.0.1.tgz",
+          "integrity": "sha512-QWw9nOYJq5PlvChLWV8i6hQHJYfvdqiXdvTupJFh0eqLZ64Xir7mKNi96d5/ZMUAqXPursfNDIDxjFgoEDUqeQ==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/content": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/content/-/content-5.0.2.tgz",
+          "integrity": "sha512-mre4dl1ygd4ZyOH3tiYBrOUBzV7Pu/EOs8VLGf58vtOEECWed8Uuw6B4iR9AN/8uQt42tB04qpVaMyoMQh0oMw==",
+          "requires": {
+            "@hapi/boom": "9.x.x"
+          }
+        },
+        "@hapi/cryptiles": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
+          "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
+          "requires": {
+            "@hapi/boom": "9.x.x"
+          }
+        },
+        "@hapi/file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/file/-/file-2.0.0.tgz",
+          "integrity": "sha512-WSrlgpvEqgPWkI18kkGELEZfXr0bYLtr16iIN4Krh9sRnzBZN6nnWxHFxtsnP684wueEySBbXPDg/WfA9xJdBQ=="
+        },
+        "@hapi/hapi": {
+          "version": "20.2.2",
+          "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
+          "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+          "requires": {
+            "@hapi/accept": "^5.0.1",
+            "@hapi/ammo": "^5.0.1",
+            "@hapi/boom": "^9.1.0",
+            "@hapi/bounce": "^2.0.0",
+            "@hapi/call": "^8.0.0",
+            "@hapi/catbox": "^11.1.1",
+            "@hapi/catbox-memory": "^5.0.0",
+            "@hapi/heavy": "^7.0.1",
+            "@hapi/hoek": "^9.0.4",
+            "@hapi/mimos": "^6.0.0",
+            "@hapi/podium": "^4.1.1",
+            "@hapi/shot": "^5.0.5",
+            "@hapi/somever": "^3.0.0",
+            "@hapi/statehood": "^7.0.4",
+            "@hapi/subtext": "^7.0.3",
+            "@hapi/teamwork": "^5.1.1",
+            "@hapi/topo": "^5.0.0",
+            "@hapi/validate": "^1.1.1"
+          }
+        },
+        "@hapi/heavy": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/heavy/-/heavy-7.0.1.tgz",
+          "integrity": "sha512-vJ/vzRQ13MtRzz6Qd4zRHWS3FaUc/5uivV2TIuExGTM9Qk+7Zzqj0e2G7EpE6KztO9SalTbiIkTh7qFKj/33cA==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/iron": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
+          "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
+          "requires": {
+            "@hapi/b64": "5.x.x",
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/cryptiles": "5.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/mimos": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+          "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "mime-db": "1.x.x"
+          }
+        },
+        "@hapi/nigel": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@hapi/nigel/-/nigel-4.0.2.tgz",
+          "integrity": "sha512-ht2KoEsDW22BxQOEkLEJaqfpoKPXxi7tvabXy7B/77eFtOyG5ZEstfZwxHQcqAiZhp58Ae5vkhEqI03kawkYNw==",
+          "requires": {
+            "@hapi/hoek": "^9.0.4",
+            "@hapi/vise": "^4.0.0"
+          }
+        },
+        "@hapi/pez": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@hapi/pez/-/pez-5.0.3.tgz",
+          "integrity": "sha512-mpikYRJjtrbJgdDHG/H9ySqYqwJ+QU/D7FXsYciS9P7NYBXE2ayKDAy3H0ou6CohOCaxPuTV4SZ0D936+VomHA==",
+          "requires": {
+            "@hapi/b64": "5.x.x",
+            "@hapi/boom": "9.x.x",
+            "@hapi/content": "^5.0.2",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/nigel": "4.x.x"
+          }
+        },
+        "@hapi/podium": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
+          "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "@hapi/teamwork": "5.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/shot": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+          "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/somever": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@hapi/somever/-/somever-3.0.1.tgz",
+          "integrity": "sha512-4ZTSN3YAHtgpY/M4GOtHUXgi6uZtG9nEZfNI6QrArhK0XN/RDVgijlb9kOmXwCR5VclDSkBul9FBvhSuKXx9+w==",
+          "requires": {
+            "@hapi/bounce": "2.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/statehood": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+          "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bounce": "2.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/cryptiles": "5.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/iron": "6.x.x",
+            "@hapi/validate": "1.x.x"
+          }
+        },
+        "@hapi/subtext": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/subtext/-/subtext-7.0.4.tgz",
+          "integrity": "sha512-Y72moHhbRuO8kwBHFEnCRw7oOnhNh4Pl+aonxAze18jkyMpE4Gwz4lNID7ei8vd3lpXC2rKdkxXJgtfY+WttRw==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/content": "^5.0.2",
+            "@hapi/file": "2.x.x",
+            "@hapi/hoek": "9.x.x",
+            "@hapi/pez": "^5.0.1",
+            "@hapi/wreck": "17.x.x"
+          }
+        },
+        "@hapi/teamwork": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+          "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
+        },
+        "@hapi/topo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/vise": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/vise/-/vise-4.0.0.tgz",
+          "integrity": "sha512-eYyLkuUiFZTer59h+SGy7hUm+qE9p+UemePTHLlIWppEd+wExn3Df5jO04bFQTm7nleF5V8CtuYQYb+VFpZ6Sg==",
+          "requires": {
+            "@hapi/hoek": "9.x.x"
+          }
+        },
+        "@hapi/wreck": {
+          "version": "17.2.0",
+          "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-17.2.0.tgz",
+          "integrity": "sha512-pJ5kjYoRPYDv+eIuiLQqhGon341fr2bNIYZjuotuPJG/3Ilzr/XtI+JAp0A86E2bYfsS3zBPABuS2ICkaXFT8g==",
+          "requires": {
+            "@hapi/boom": "9.x.x",
+            "@hapi/bourne": "2.x.x",
+            "@hapi/hoek": "9.x.x"
+          }
         }
       }
     },
@@ -12431,6 +12971,25 @@
           "version": "8.5.1",
           "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
           "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow=="
+        }
+      }
+    },
+    "@hapi/validate": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
+      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/topo": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+          "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
         }
       }
     },

--- a/hapi18/package.json
+++ b/hapi18/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.31.0",
-    "@hapi/glue": "^6.2.0",
-    "@hapi/hapi": "^18.4.0",
+    "@hapi/glue": "^8.0.0",
+    "@hapi/hapi": "^18.4.1",
     "@hapi/hoek": "^9.0.3",
     "@hapi/inert": "^5.2.2",
     "@hapi/vision": "^6.0.0",

--- a/hapi19/package-lock.json
+++ b/hapi19/package-lock.json
@@ -10,8 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@contrast/test-bench-utils": "^3.31.0",
-        "@hapi/glue": "^7.0.0",
-        "@hapi/hapi": "^19.1.1",
+        "@hapi/glue": "^8.0.0",
+        "@hapi/hapi": "^19.2.0",
         "@hapi/hoek": "^9.0.4",
         "@hapi/inert": "^6.0.1",
         "@hapi/vision": "^6.0.0",
@@ -1729,13 +1729,58 @@
       "deprecated": "Moved to 'npm install @sideway/formula'"
     },
     "node_modules/@hapi/glue": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-7.0.0.tgz",
-      "integrity": "sha512-1g5mzwUxZNnzil8Qz6IgFdjPSwmn3rJ5YIgy8h+V1JzF2ASdFf73NtlxdIG7BwwGcSnIwcPrVh1W6PWW2LqfhA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-8.0.0.tgz",
+      "integrity": "sha512-dqAQ401MTDpTUnPUtUZ/RIJOE+ROTjhq1YgPeuAVMYpoYlh55PNNJq6YBDBlye5VcF9uYtL1h3VnRMZz2NSlXw==",
       "dependencies": {
-        "@hapi/hapi": "19.x.x",
+        "@hapi/hapi": "20.x.x",
         "@hapi/hoek": "9.x.x",
-        "@hapi/joi": "17.x.x"
+        "@hapi/validate": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/hapi": {
+      "version": "20.2.2",
+      "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
+      "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+      "dependencies": {
+        "@hapi/accept": "^5.0.1",
+        "@hapi/ammo": "^5.0.1",
+        "@hapi/boom": "^9.1.0",
+        "@hapi/bounce": "^2.0.0",
+        "@hapi/call": "^8.0.0",
+        "@hapi/catbox": "^11.1.1",
+        "@hapi/catbox-memory": "^5.0.0",
+        "@hapi/heavy": "^7.0.1",
+        "@hapi/hoek": "^9.0.4",
+        "@hapi/mimos": "^6.0.0",
+        "@hapi/podium": "^4.1.1",
+        "@hapi/shot": "^5.0.5",
+        "@hapi/somever": "^3.0.0",
+        "@hapi/statehood": "^7.0.4",
+        "@hapi/subtext": "^7.0.3",
+        "@hapi/teamwork": "^5.1.1",
+        "@hapi/topo": "^5.0.0",
+        "@hapi/validate": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/mimos": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+      "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+      "dependencies": {
+        "@hapi/hoek": "9.x.x",
+        "mime-db": "1.x.x"
+      }
+    },
+    "node_modules/@hapi/glue/node_modules/@hapi/teamwork": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@hapi/hapi": {
@@ -1878,9 +1923,9 @@
       }
     },
     "node_modules/@hapi/shot": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.3.tgz",
-      "integrity": "sha512-qbccs8KL4YSL9x0J/17Z6Udmtrrn32ieGbrCW8iivl2ha8YzlDy9Wvv1pFKh3mzbTsomWHGLF3UsKcQFk/BqPg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
       "dependencies": {
         "@hapi/hoek": "9.x.x",
         "@hapi/validate": "1.x.x"
@@ -1896,9 +1941,9 @@
       }
     },
     "node_modules/@hapi/statehood": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
-      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
       "dependencies": {
         "@hapi/boom": "9.x.x",
         "@hapi/bounce": "2.x.x",
@@ -12169,13 +12214,54 @@
       "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
     },
     "@hapi/glue": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-7.0.0.tgz",
-      "integrity": "sha512-1g5mzwUxZNnzil8Qz6IgFdjPSwmn3rJ5YIgy8h+V1JzF2ASdFf73NtlxdIG7BwwGcSnIwcPrVh1W6PWW2LqfhA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/glue/-/glue-8.0.0.tgz",
+      "integrity": "sha512-dqAQ401MTDpTUnPUtUZ/RIJOE+ROTjhq1YgPeuAVMYpoYlh55PNNJq6YBDBlye5VcF9uYtL1h3VnRMZz2NSlXw==",
       "requires": {
-        "@hapi/hapi": "19.x.x",
+        "@hapi/hapi": "20.x.x",
         "@hapi/hoek": "9.x.x",
-        "@hapi/joi": "17.x.x"
+        "@hapi/validate": "1.x.x"
+      },
+      "dependencies": {
+        "@hapi/hapi": {
+          "version": "20.2.2",
+          "resolved": "https://registry.npmjs.org/@hapi/hapi/-/hapi-20.2.2.tgz",
+          "integrity": "sha512-crhU6TIKt7QsksWLYctDBAXogk9PYAm7UzdpETyuBHC2pCa6/+B5NykiOVLG/3FCIgHo/raPVtan8bYtByHORQ==",
+          "requires": {
+            "@hapi/accept": "^5.0.1",
+            "@hapi/ammo": "^5.0.1",
+            "@hapi/boom": "^9.1.0",
+            "@hapi/bounce": "^2.0.0",
+            "@hapi/call": "^8.0.0",
+            "@hapi/catbox": "^11.1.1",
+            "@hapi/catbox-memory": "^5.0.0",
+            "@hapi/heavy": "^7.0.1",
+            "@hapi/hoek": "^9.0.4",
+            "@hapi/mimos": "^6.0.0",
+            "@hapi/podium": "^4.1.1",
+            "@hapi/shot": "^5.0.5",
+            "@hapi/somever": "^3.0.0",
+            "@hapi/statehood": "^7.0.4",
+            "@hapi/subtext": "^7.0.3",
+            "@hapi/teamwork": "^5.1.1",
+            "@hapi/topo": "^5.0.0",
+            "@hapi/validate": "^1.1.1"
+          }
+        },
+        "@hapi/mimos": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/mimos/-/mimos-6.0.0.tgz",
+          "integrity": "sha512-Op/67tr1I+JafN3R3XN5DucVSxKRT/Tc+tUszDwENoNpolxeXkhrJ2Czt6B6AAqrespHoivhgZBWYSuANN9QXg==",
+          "requires": {
+            "@hapi/hoek": "9.x.x",
+            "mime-db": "1.x.x"
+          }
+        },
+        "@hapi/teamwork": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
+          "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
+        }
       }
     },
     "@hapi/hapi": {
@@ -12308,9 +12394,9 @@
       }
     },
     "@hapi/shot": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.3.tgz",
-      "integrity": "sha512-qbccs8KL4YSL9x0J/17Z6Udmtrrn32ieGbrCW8iivl2ha8YzlDy9Wvv1pFKh3mzbTsomWHGLF3UsKcQFk/BqPg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@hapi/shot/-/shot-5.0.5.tgz",
+      "integrity": "sha512-x5AMSZ5+j+Paa8KdfCoKh+klB78otxF+vcJR/IoN91Vo2e5ulXIW6HUsFTCU+4W6P/Etaip9nmdAx2zWDimB2A==",
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/validate": "1.x.x"
@@ -12326,9 +12412,9 @@
       }
     },
     "@hapi/statehood": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.3.tgz",
-      "integrity": "sha512-pYB+pyCHkf2Amh67QAXz7e/DN9jcMplIL7Z6N8h0K+ZTy0b404JKPEYkbWHSnDtxLjJB/OtgElxocr2fMH4G7w==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/statehood/-/statehood-7.0.4.tgz",
+      "integrity": "sha512-Fia6atroOVmc5+2bNOxF6Zv9vpbNAjEXNcUbWXavDqhnJDlchwUUwKS5LCi5mGtCTxRhUKKHwuxuBZJkmLZ7fw==",
       "requires": {
         "@hapi/boom": "9.x.x",
         "@hapi/bounce": "2.x.x",

--- a/hapi19/package.json
+++ b/hapi19/package.json
@@ -25,8 +25,8 @@
   },
   "dependencies": {
     "@contrast/test-bench-utils": "^3.31.0",
-    "@hapi/glue": "^7.0.0",
-    "@hapi/hapi": "^19.1.1",
+    "@hapi/glue": "^8.0.0",
+    "@hapi/hapi": "^19.2.0",
     "@hapi/hoek": "^9.0.4",
     "@hapi/inert": "^6.0.1",
     "@hapi/vision": "^6.0.0",


### PR DESCRIPTION
If you run Hapi 19 or 18 (with or without the agent) and go to http://localhost:3000/pathTraversal/body/fsReadFile/unsafe you'll see the request just hang. This appears to be a problem with components of Hapi no longer being compatible with the newer versions of Node (specifically @hapi/glue https://github.com/hapijs/glue/milestone/25?closed=1).

Run Hapi 19 or 18 with Node 12 and you'll see the request go through just fine. Bump to 14 or above, and you'll start to see the issue. I think this is good reason to discontinue our support of Hapi <20 but, in the meantime, bumping to use v8 of glue fixes the issue. I built new Docker images with the change and ran the V5 screener tests and confirmed this fixes the Path-Traversal failures.